### PR TITLE
chore(dev): one-command dev environment with Docker + Mailpit

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,40 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Variables prêtes à l'emploi pour développer en local avec Docker.
+#
+#   cp .env.development.example .env
+#   make dev-up
+#   make dev-setup     # installe deps, applique migrations, seed
+#   make dev           # npm run dev
+#
+# Les valeurs ci-dessous correspondent aux services exposés par
+# docker-compose.dev.yml. Ne PAS utiliser ces credentials en production.
+# ──────────────────────────────────────────────────────────────────────────────
+
+# PostgreSQL (docker-compose.dev.yml)
+DATABASE_URL="postgresql://benevoles:benevoles@localhost:5432/benevoles?schema=public"
+
+# Compte super admin créé par `npm run db:seed`
+ADMIN_EMAIL="admin@local"
+ADMIN_PASSWORD="admin"
+
+# NextAuth — généré par `make dev-setup` si laissé vide
+AUTH_SECRET=""
+
+# SMTP local via Mailpit (docker-compose.dev.yml)
+# Lecture des emails capturés sur http://localhost:8025
+SMTP_HOST="localhost"
+SMTP_PORT="1025"
+SMTP_SECURE="false"
+SMTP_USER="dev"
+SMTP_PASSWORD="dev"
+EMAIL_FROM="Bénévoles <no-reply@local>"
+
+# (Optionnel) Adresse qui reçoit une copie à chaque inscription
+ADMIN_NOTIFICATION_EMAIL=""
+
+# URL publique de l'app (utilisée dans les emails)
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+
+# NextAuth derrière un reverse proxy → laissé tel quel en dev
+AUTH_URL="http://localhost:3000"
+AUTH_TRUST_HOST="true"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,88 @@
+# Bénévoles — tâches de développement.
+# Usage : `make` (équivalent à `make help`).
+
+.PHONY: help dev dev-up dev-down dev-logs dev-reset dev-setup db-migrate db-seed db-studio test lint typecheck install
+
+DEFAULT_GOAL := help
+
+# ── Aide ─────────────────────────────────────────────────────────────────────
+
+help: ## Affiche cette aide
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+# ── Setup initial ─────────────────────────────────────────────────────────────
+
+dev-setup: ## Setup complet : .env, deps, postgres, migrations, seed
+	@if [ ! -f .env ]; then \
+		echo "→ Copie .env.development.example → .env"; \
+		cp .env.development.example .env; \
+	fi
+	@if ! grep -q '^AUTH_SECRET=".\+"' .env; then \
+		SECRET=$$(openssl rand -base64 48 | tr -d '\n='); \
+		if [ "$$(uname)" = "Darwin" ]; then \
+			sed -i '' "s|^AUTH_SECRET=.*|AUTH_SECRET=\"$$SECRET\"|" .env; \
+		else \
+			sed -i "s|^AUTH_SECRET=.*|AUTH_SECRET=\"$$SECRET\"|" .env; \
+		fi; \
+		echo "→ AUTH_SECRET généré"; \
+	fi
+	@$(MAKE) install
+	@$(MAKE) dev-up
+	@echo "→ Attente de PostgreSQL…"
+	@until docker exec benevoles_postgres_dev pg_isready -U benevoles >/dev/null 2>&1; do sleep 0.5; done
+	@$(MAKE) db-migrate
+	@$(MAKE) db-seed
+	@echo ""
+	@echo "✅ Prêt ! Lance \`make dev\` pour démarrer le serveur."
+	@echo "   • App :     http://localhost:3000"
+	@echo "   • Admin :   http://localhost:3000/admin"
+	@echo "   • Mailpit : http://localhost:8025"
+
+install: ## Installe les dépendances npm
+	npm install --legacy-peer-deps
+
+# ── Stack docker ──────────────────────────────────────────────────────────────
+
+dev-up: ## Démarre postgres + mailpit (docker-compose.dev.yml)
+	docker compose -f docker-compose.dev.yml up -d
+
+dev-down: ## Stoppe la stack dev
+	docker compose -f docker-compose.dev.yml down
+
+dev-logs: ## Suit les logs des services dev
+	docker compose -f docker-compose.dev.yml logs -f
+
+dev-reset: ## ⚠ Supprime la DB locale (volume) et redémarre tout
+	docker compose -f docker-compose.dev.yml down -v
+	docker compose -f docker-compose.dev.yml up -d
+	@echo "→ Attente de PostgreSQL…"
+	@until docker exec benevoles_postgres_dev pg_isready -U benevoles >/dev/null 2>&1; do sleep 0.5; done
+	@$(MAKE) db-migrate
+	@$(MAKE) db-seed
+
+# ── App ───────────────────────────────────────────────────────────────────────
+
+dev: ## Lance le serveur Next.js en dev
+	npm run dev
+
+# ── Base de données ──────────────────────────────────────────────────────────
+
+db-migrate: ## Applique les migrations Prisma
+	npx prisma migrate deploy
+
+db-seed: ## Crée le compte admin + données démo
+	npm run db:seed
+
+db-studio: ## Ouvre Prisma Studio (http://localhost:5555)
+	npm run db:studio
+
+# ── Qualité ──────────────────────────────────────────────────────────────────
+
+test: ## Lance la suite de tests (vitest)
+	npm test
+
+lint: ## Lint le code
+	npm run lint
+
+typecheck: ## Vérifie les types TypeScript
+	npx tsc --noEmit

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Bénévoles — tâches de développement.
 # Usage : `make` (équivalent à `make help`).
 
-.PHONY: help dev dev-up dev-down dev-logs dev-reset dev-setup db-migrate db-seed db-studio test lint typecheck install
+.PHONY: help dev dev-up dev-down dev-logs dev-reset dev-setup db-generate db-migrate db-seed db-studio test lint typecheck install
 
 DEFAULT_GOAL := help
 
@@ -27,6 +27,7 @@ dev-setup: ## Setup complet : .env, deps, postgres, migrations, seed
 		echo "→ AUTH_SECRET généré"; \
 	fi
 	@$(MAKE) install
+	@$(MAKE) db-generate
 	@$(MAKE) dev-up
 	@echo "→ Attente de PostgreSQL…"
 	@until docker exec benevoles_postgres_dev pg_isready -U benevoles >/dev/null 2>&1; do sleep 0.5; done
@@ -66,15 +67,20 @@ dev: ## Lance le serveur Next.js en dev
 	npm run dev
 
 # ── Base de données ──────────────────────────────────────────────────────────
+# Prisma 7 (avec prisma.config.ts) ne charge pas .env automatiquement.
+# Ces commandes utilisent --env-file pour le faire explicitement.
+
+db-generate: ## Génère le client Prisma (src/generated/prisma)
+	node --env-file=.env node_modules/.bin/prisma generate
 
 db-migrate: ## Applique les migrations Prisma
-	npx prisma migrate deploy
+	node --env-file=.env node_modules/.bin/prisma migrate deploy
 
 db-seed: ## Crée le compte admin + données démo
-	npm run db:seed
+	node --env-file=.env node_modules/.bin/prisma db seed
 
 db-studio: ## Ouvre Prisma Studio (http://localhost:5555)
-	npm run db:studio
+	node --env-file=.env node_modules/.bin/prisma studio
 
 # ── Qualité ──────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -42,34 +42,44 @@ Application de gestion de bénévoles pour événements. Les organisateurs crée
 ## Prérequis
 
 - Node.js **22** (`nvm use 22`)
-- PostgreSQL 16+
+- Docker (pour la stack dev locale)
 
-## Installation
+## Démarrage rapide (dev)
+
+Tout est piloté par le `Makefile`. Une seule commande pour partir de zéro :
 
 ```bash
 git clone <repo>
 cd benevoles
-npm install
-cp .env.example .env
-# Remplir .env (voir section Variables d'environnement)
+make dev-setup   # .env, npm install, docker (postgres + mailpit), migrations, seed
+make dev         # lance le serveur Next.js
 ```
 
-### Base de données
+Trois services exposés en dev :
+- App : http://localhost:3000 (admin sur `/admin`, identifiants par défaut `admin@local` / `admin`)
+- Mailpit : http://localhost:8025 (captures de tous les emails envoyés en dev)
+- Postgres : `localhost:5432` (`benevoles` / `benevoles`)
+
+| Commande | Effet |
+|----------|-------|
+| `make help` | Liste toutes les tâches |
+| `make dev` | `npm run dev` |
+| `make dev-up` / `dev-down` | Démarre / arrête postgres + mailpit |
+| `make dev-reset` | ⚠ Supprime la DB locale et la réinitialise |
+| `make db-migrate` / `db-seed` / `db-studio` | Tâches Prisma |
+| `make test` / `lint` / `typecheck` | Qualité |
+
+### Setup manuel (sans Make)
 
 ```bash
-# Créer les tables
-npm run db:migrate
-
-# Créer le compte admin (+ données de démonstration)
+docker compose -f docker-compose.dev.yml up -d
+npm install --legacy-peer-deps
+cp .env.development.example .env
+# Génère un AUTH_SECRET et colle-le dans .env
+openssl rand -base64 48
+npx prisma migrate deploy
 npm run db:seed
-```
-
-### Développement
-
-```bash
 npm run dev
-# → http://localhost:3000         (vue publique)
-# → http://localhost:3000/admin   (interface admin)
 ```
 
 ## Variables d'environnement

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,17 @@
-# Juste PostgreSQL — pour développer avec `npm run dev` en local
+# Stack de développement local — à utiliser avec `npm run dev`
+#
+#   make dev-up      # démarre postgres + mailpit
+#   make dev-down    # arrête tout
+#   make dev-logs    # suit les logs
+#   make dev-reset   # wipe la DB (⚠ destructif)
+#
+# Postgres expose le port 5432 (DATABASE_URL dans .env).
+# Mailpit expose deux ports : 1025 (SMTP) et 8025 (UI web pour lire les emails).
+
 services:
   postgres:
     image: postgres:16-alpine
+    container_name: benevoles_postgres_dev
     restart: unless-stopped
     environment:
       POSTGRES_DB: benevoles
@@ -16,6 +26,19 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+
+  # Mailpit : capture tous les emails envoyés en dev pour les inspecter
+  # dans une UI web sans envoyer de vraies notifications.
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: benevoles_mailpit_dev
+    restart: unless-stopped
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # UI web → http://localhost:8025
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
 
 volumes:
   postgres_dev_data:

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
-    seed: "tsx ./prisma/seed.ts",
+    seed: "./node_modules/.bin/tsx ./prisma/seed.ts",
   },
   datasource: {
     url: process.env["DATABASE_URL"],

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
+    seed: "tsx ./prisma/seed.ts",
   },
   datasource: {
     url: process.env["DATABASE_URL"],

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -36,6 +36,11 @@ async function main() {
       endDate: new Date("2026-06-15"),
       publicInstructions: "Merci pour votre aide ! Présentez-vous 15 minutes avant le début de votre créneau.",
       confirmationMessage: "Merci pour votre inscription ! Nous vous contacterons si besoin. À bientôt !",
+      showSchedule: [
+        { name: "Représentation samedi après-midi", date: "2026-06-14", startTime: "14:30", endTime: "16:00" },
+        { name: "Représentation samedi soir",       date: "2026-06-14", startTime: "20:00", endTime: "21:30" },
+        { name: "Représentation dimanche",          date: "2026-06-15", startTime: "14:30", endTime: "16:00" },
+      ],
     },
   })
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -23,9 +23,15 @@ async function main() {
 
   console.log(`✓ Admin créé : ${email}`)
 
+  const demoShowSchedule = [
+    { name: "Représentation samedi après-midi", date: "2026-06-14", startTime: "14:30", endTime: "16:00" },
+    { name: "Représentation samedi soir",       date: "2026-06-14", startTime: "20:00", endTime: "21:30" },
+    { name: "Représentation dimanche",          date: "2026-06-15", startTime: "14:30", endTime: "16:00" },
+  ]
+
   const event = await prisma.event.upsert({
     where: { slug: "spectacle-cirque-2026" },
-    update: {},
+    update: { showSchedule: demoShowSchedule },
     create: {
       slug: "spectacle-cirque-2026",
       title: "Spectacle de Cirque 2026",
@@ -36,11 +42,7 @@ async function main() {
       endDate: new Date("2026-06-15"),
       publicInstructions: "Merci pour votre aide ! Présentez-vous 15 minutes avant le début de votre créneau.",
       confirmationMessage: "Merci pour votre inscription ! Nous vous contacterons si besoin. À bientôt !",
-      showSchedule: [
-        { name: "Représentation samedi après-midi", date: "2026-06-14", startTime: "14:30", endTime: "16:00" },
-        { name: "Représentation samedi soir",       date: "2026-06-14", startTime: "20:00", endTime: "21:30" },
-        { name: "Représentation dimanche",          date: "2026-06-15", startTime: "14:30", endTime: "16:00" },
-      ],
+      showSchedule: demoShowSchedule,
     },
   })
 


### PR DESCRIPTION
## Summary

Sets up a `make dev-setup && make dev` workflow that makes a fresh clone immediately operational.

## Changes

- **`docker-compose.dev.yml`**: adds Mailpit (SMTP `:1025`, web UI `:8025`) to capture local emails without a real SMTP server.
- **`.env.development.example`**: ready-to-use values for the Docker stack (postgres `benevoles/benevoles`, local Mailpit).
- **`Makefile`**: tasks `dev-setup`, `dev-up`, `dev-down`, `dev-reset`, `db-generate`, `db-migrate`, `db-seed`, `db-studio`, `test`, `lint`, `typecheck`. All Prisma commands use `node --env-file=.env` because Prisma 7 (with `prisma.config.ts`) no longer loads `.env` automatically.
- **`prisma.config.ts`**: declares the seed (Prisma 7 no longer reads it from `package.json`), points to `./node_modules/.bin/tsx`.
- **`README.md`**: replaces the manual install docs with `make dev-setup` + `make dev` (manual fallback preserved).
- **`prisma/seed.ts`**: adds 3 performances to the `showSchedule` of the demo event + forces update on existing seed.

## Test plan

- [ ] `make dev-setup` chains `.env`, deps, postgres, Mailpit, migrations, seed without error
- [ ] `make dev` starts Next.js on `:3000`
- [ ] http://localhost:8025 receives emails sent in dev
- [ ] Admin event page displays the 3 demo performances

---
_Generated by [Claude Code](https://claude.ai/code/session_017XAA7o12GpsXpUeyGNynZH)_