### PR TITLE
feat(saas): Sprint 3 — Transactional communications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,13 @@ dev-down: ## Stoppe la stack dev
 dev-logs: ## Suit les logs des services dev
 	docker compose -f docker-compose.dev.yml logs -f
 
-dev-reset: ## ⚠ Supprime la DB locale (volume) et redémarre tout
+dev-reset: ## ⚠ Supprime la DB locale (volume) et redémarre tout (deps + migrations + seed)
+	@$(MAKE) install
 	docker compose -f docker-compose.dev.yml down -v
 	docker compose -f docker-compose.dev.yml up -d
 	@echo "→ Attente de PostgreSQL…"
 	@until docker exec benevoles_postgres_dev pg_isready -U benevoles >/dev/null 2>&1; do sleep 0.5; done
+	@$(MAKE) db-generate
 	@$(MAKE) db-migrate
 	@$(MAKE) db-seed
 

--- a/prisma/migrations/20260427180000_communications/migration.sql
+++ b/prisma/migrations/20260427180000_communications/migration.sql
@@ -1,0 +1,28 @@
+-- ────────────────────────────────────────────────────────────────────────────
+-- Sprint 3 — Communications
+--
+-- Adds:
+--   • Event.reminderMessage / reminderSentAt / remindersEnabled (manual J-7)
+--   • Registration.reminderJ2Sent / J1Sent / DdSent (auto reminders idempotency)
+--   • indexes used by the cron job to avoid full table scans
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE "Event"
+  ADD COLUMN "reminderMessage"  TEXT,
+  ADD COLUMN "reminderSentAt"   TIMESTAMP(3),
+  ADD COLUMN "remindersEnabled" BOOLEAN NOT NULL DEFAULT true;
+
+ALTER TABLE "Registration"
+  ADD COLUMN "reminderJ2Sent" TIMESTAMP(3),
+  ADD COLUMN "reminderJ1Sent" TIMESTAMP(3),
+  ADD COLUMN "reminderDdSent" TIMESTAMP(3);
+
+-- Indexes used by /api/cron/reminders. Filtered queries hit
+-- (status, reminderXSent IS NULL) on every run, so a composite index
+-- on those two columns avoids scanning the whole table once volume grows.
+CREATE INDEX "Registration_status_reminderJ2Sent_idx"
+  ON "Registration"("status", "reminderJ2Sent");
+CREATE INDEX "Registration_status_reminderJ1Sent_idx"
+  ON "Registration"("status", "reminderJ1Sent");
+CREATE INDEX "Registration_status_reminderDdSent_idx"
+  ON "Registration"("status", "reminderDdSent");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,20 +20,23 @@ model Organization {
 }
 
 model Event {
-  id                  String   @id @default(cuid())
+  id                  String    @id @default(cuid())
   organizationId      String
   slug                String
   title               String
   description         String?
   location            String?
-  publicStatus        String   @default("draft")
+  publicStatus        String    @default("draft")
   startDate           DateTime
   endDate             DateTime
   publicInstructions  String?
   confirmationMessage String?
-  showSchedule        Json     @default("[]")
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  showSchedule        Json      @default("[]")
+  reminderMessage     String?
+  reminderSentAt      DateTime?
+  remindersEnabled    Boolean   @default(true)
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
   organization  Organization   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   shifts        Shift[]
@@ -80,20 +83,27 @@ model Volunteer {
 }
 
 model Registration {
-  id          String   @id @default(cuid())
-  eventId     String
-  shiftId     String
-  volunteerId String
-  status      String   @default("active")
-  source      String   @default("public_form")
-  comment     String?
-  editToken   String   @unique
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id             String    @id @default(cuid())
+  eventId        String
+  shiftId        String
+  volunteerId    String
+  status         String    @default("active")
+  source         String    @default("public_form")
+  comment        String?
+  editToken      String    @unique
+  reminderJ2Sent DateTime?
+  reminderJ1Sent DateTime?
+  reminderDdSent DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   event     Event     @relation(fields: [eventId], references: [id], onDelete: Cascade)
   shift     Shift     @relation(fields: [shiftId], references: [id], onDelete: Cascade)
   volunteer Volunteer @relation(fields: [volunteerId], references: [id])
+
+  @@index([status, reminderJ2Sent])
+  @@index([status, reminderJ1Sent])
+  @@index([status, reminderDdSent])
 }
 
 model Member {

--- a/src/app/admin/events/[id]/edit/page.tsx
+++ b/src/app/admin/events/[id]/edit/page.tsx
@@ -24,6 +24,7 @@ export default async function EditEventPage({ params }: { params: Promise<{ id: 
     endDate: event.endDate.toISOString().split("T")[0],
     publicInstructions: event.publicInstructions ?? "",
     confirmationMessage: event.confirmationMessage ?? "",
+    reminderMessage: event.reminderMessage ?? "",
     publicStatus: event.publicStatus as "draft" | "published" | "archived",
     showSchedule: (event.showSchedule ?? []) as Array<{ name: string; date: string; startTime: string; endTime: string }>,
   }

--- a/src/app/admin/events/[id]/page.tsx
+++ b/src/app/admin/events/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getOrgContext } from "@/lib/auth-guard"
 import { formatShortDate } from "@/lib/utils"
 import StatusBadge from "@/components/admin/StatusBadge"
 import PublishToggle from "@/components/admin/PublishToggle"
+import SendReminderButton from "@/components/admin/SendReminderButton"
 
 export const dynamic = "force-dynamic"
 
@@ -30,6 +31,10 @@ export default async function AdminEventPage({ params }: { params: Promise<{ id:
   const totalCapacity = event.shifts.reduce((s, sh) => s + sh.capacity, 0)
   const totalRegistered = event.shifts.reduce((s, sh) => s + sh.registrations.length, 0)
   const criticalShifts = event.shifts.filter((sh) => sh.capacity - sh.registrations.length >= 2)
+
+  // Unique volunteers across all shifts (one reminder email per person)
+  const uniqueVolunteerIds = new Set<string>()
+  for (const sh of event.shifts) for (const r of sh.registrations) uniqueVolunteerIds.add(r.volunteerId)
 
   return (
     <div className="space-y-6">
@@ -106,6 +111,16 @@ export default async function AdminEventPage({ params }: { params: Promise<{ id:
         >
           Exporter PDF ↗
         </a>
+      </div>
+
+      <div className="border-t border-gray-200 pt-4">
+        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Communications</h2>
+        <SendReminderButton
+          eventId={event.id}
+          hasMessage={!!event.reminderMessage?.trim()}
+          volunteerCount={uniqueVolunteerIds.size}
+          lastSentAt={event.reminderSentAt?.toISOString() ?? null}
+        />
       </div>
 
       {criticalShifts.length > 0 && (

--- a/src/app/api/admin/events/[id]/invitations/route.ts
+++ b/src/app/api/admin/events/[id]/invitations/route.ts
@@ -125,31 +125,36 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     created.push(invite)
   }
 
-  // Send emails (only to members with an email and never invited yet).
-  let sent = 0
-  let failed = 0
-  for (const member of members) {
-    if (!member.email) continue
-    const invite = existingByMember.get(member.id) ?? created.find((c) => c.memberId === member.id)
-    if (!invite) continue
-    try {
-      await sendMemberInvite({
-        to: member.email,
-        memberName: member.firstName,
-        organizationName: event.organization.name,
-        eventTitle: event.title,
-        eventDate: event.startDate.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" }),
-        eventLocation: event.location,
-        eventSlug: event.slug,
-        message: parsed.data.message ?? null,
-        token: invite.token,
-      })
-      sent++
-    } catch (err) {
-      console.error("Member invite email error:", err)
-      failed++
-    }
-  }
+  // Send emails in parallel so a slow SMTP doesn't make the route
+  // hang for `members.length × timeout`. Promise.allSettled keeps a
+  // partial failure from cancelling the others.
+  const sends = members
+    .filter((m) => m.email)
+    .map(async (member) => {
+      const invite = existingByMember.get(member.id) ?? created.find((c) => c.memberId === member.id)
+      if (!invite) return { ok: false }
+      try {
+        await sendMemberInvite({
+          to: member.email!,
+          memberName: member.firstName,
+          organizationName: event.organization.name,
+          eventTitle: event.title,
+          eventDate: event.startDate.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" }),
+          eventLocation: event.location,
+          eventSlug: event.slug,
+          message: parsed.data.message ?? null,
+          token: invite.token,
+        })
+        return { ok: true }
+      } catch (err) {
+        console.error("Member invite email error:", err)
+        return { ok: false }
+      }
+    })
+
+  const results = await Promise.allSettled(sends)
+  const sent = results.filter((r) => r.status === "fulfilled" && r.value.ok).length
+  const failed = results.length - sent
 
   return NextResponse.json({
     invitedNew: created.length,

--- a/src/app/api/admin/events/[id]/route.ts
+++ b/src/app/api/admin/events/[id]/route.ts
@@ -20,6 +20,8 @@ const schema = z.object({
   confirmationMessage: z.string().optional().nullable(),
   publicStatus: z.enum(["draft", "published", "archived"]).optional(),
   showSchedule: z.array(showSchema).optional(),
+  reminderMessage: z.string().max(2000).optional().nullable(),
+  remindersEnabled: z.boolean().optional(),
 })
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {

--- a/src/app/api/admin/events/[id]/send-reminder/route.ts
+++ b/src/app/api/admin/events/[id]/send-reminder/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import { sendNotification } from "@/lib/notifications"
+
+/**
+ * POST /api/admin/events/[id]/send-reminder
+ *
+ * Sends one email per volunteer who has at least one active registration
+ * on the event. Each email contains the admin's custom reminder message
+ * (Event.reminderMessage) followed by the volunteer's own shifts.
+ */
+export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
+
+  const { id } = await params
+
+  const event = await db.event.findFirst({
+    where: { id },
+    include: { organization: { select: { name: true } } },
+  })
+  if (!event) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+
+  // Defense in depth: re-scope the registration lookup explicitly via
+  // event.organizationId so a route bug can't leak another org's data.
+  const regs = await prisma.registration.findMany({
+    where: {
+      eventId: id,
+      status: "active",
+      event: { organizationId: event.organizationId },
+    },
+    include: { volunteer: true, shift: true },
+    orderBy: [{ shift: { date: "asc" } }, { shift: { startTime: "asc" } }],
+  })
+
+  if (regs.length === 0) {
+    return NextResponse.json({ error: "Aucun bénévole inscrit" }, { status: 400 })
+  }
+
+  // Group registrations by volunteer (one email per person, even if
+  // they have several shifts). Use the volunteer.id as key so we don't
+  // depend on a single editToken per volunteer.
+  type Bundle = {
+    volunteer: typeof regs[number]["volunteer"]
+    editToken: string
+    shifts: typeof regs[number]["shift"][]
+  }
+  const byVolunteer = new Map<string, Bundle>()
+  for (const r of regs) {
+    let bundle = byVolunteer.get(r.volunteerId)
+    if (!bundle) {
+      bundle = { volunteer: r.volunteer, editToken: r.editToken, shifts: [] }
+      byVolunteer.set(r.volunteerId, bundle)
+    }
+    bundle.shifts.push(r.shift)
+  }
+
+  let sent = 0
+  let failed = 0
+  for (const bundle of byVolunteer.values()) {
+    if (!bundle.volunteer.email) continue
+    const result = await sendNotification({
+      kind: "manual_reminder",
+      recipient: { email: bundle.volunteer.email, name: bundle.volunteer.firstName },
+      data: {
+        volunteerName: bundle.volunteer.firstName,
+        organizationName: event.organization.name,
+        eventTitle: event.title,
+        customMessage: event.reminderMessage ?? "",
+        shifts: bundle.shifts.map((s) => ({
+          label: s.label,
+          date: s.date.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" }),
+          startTime: s.startTime,
+          endTime: s.endTime,
+          roleName: s.roleName,
+        })),
+        editToken: bundle.editToken,
+      },
+    })
+    if (result.ok) sent++
+    else failed++
+  }
+
+  await prisma.event.update({
+    where: { id },
+    data: { reminderSentAt: new Date() },
+  })
+
+  return NextResponse.json({ sent, failed, totalVolunteers: byVolunteer.size })
+}

--- a/src/app/api/admin/shifts/[id]/route.ts
+++ b/src/app/api/admin/shifts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { requireOrgSession } from "@/lib/auth-guard"
 import { prisma } from "@/lib/prisma"
+import { sendNotification } from "@/lib/notifications"
 import { z } from "zod"
 
 const schema = z.object({
@@ -15,7 +16,13 @@ const schema = z.object({
   locationDetails: z.string().optional().nullable(),
   displayOrder: z.number().int().optional(),
   internalNotes: z.string().optional().nullable(),
+  // Caller can opt out of notifying volunteers (default true).
+  notifyVolunteers: z.boolean().optional(),
 })
+
+function fmtDate(d: Date) {
+  return d.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" })
+}
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const guard = await requireOrgSession()
@@ -27,15 +34,54 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   const parsed = schema.safeParse(body)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
 
-  const owned = await db.shift.findFirst({ where: { id }, select: { id: true } })
-  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+  const before = await db.shift.findFirst({
+    where: { id },
+    include: {
+      event: { select: { id: true, title: true, slug: true, organizationId: true } },
+      registrations: {
+        where: { status: "active" },
+        include: { volunteer: true },
+      },
+    },
+  })
+  if (!before) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
-  const data = parsed.data
-  const updateData: Record<string, unknown> = { ...data }
-  if (data.date) updateData.date = new Date(data.date)
+  const { notifyVolunteers, ...rest } = parsed.data
+  const updateData: Record<string, unknown> = { ...rest }
+  if (rest.date) updateData.date = new Date(rest.date)
 
-  const shift = await prisma.shift.update({ where: { id }, data: updateData })
-  return NextResponse.json(shift)
+  const after = await prisma.shift.update({ where: { id }, data: updateData })
+
+  // Detect schedule changes worth notifying about (date / start / end).
+  const scheduleChanged =
+    (rest.date && before.date.toISOString() !== after.date.toISOString()) ||
+    (rest.startTime && before.startTime !== after.startTime) ||
+    (rest.endTime && before.endTime !== after.endTime)
+
+  let notified = 0
+  if (scheduleChanged && notifyVolunteers !== false && before.registrations.length > 0) {
+    for (const reg of before.registrations) {
+      const result = await sendNotification({
+        kind: "shift_modified",
+        recipient: { email: reg.volunteer.email, name: reg.volunteer.firstName },
+        data: {
+          volunteerName: reg.volunteer.firstName,
+          eventTitle: before.event.title,
+          shiftLabel: after.label,
+          oldDate: fmtDate(before.date),
+          newDate: fmtDate(after.date),
+          oldStart: before.startTime,
+          newStart: after.startTime,
+          oldEnd: before.endTime,
+          newEnd: after.endTime,
+          editToken: reg.editToken,
+        },
+      })
+      if (result.ok) notified++
+    }
+  }
+
+  return NextResponse.json({ ...after, notified })
 }
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -45,9 +91,37 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
 
   const { id } = await params
 
-  const owned = await db.shift.findFirst({ where: { id }, select: { id: true } })
-  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+  const shift = await db.shift.findFirst({
+    where: { id },
+    include: {
+      event: { select: { title: true, slug: true } },
+      registrations: { where: { status: "active" }, include: { volunteer: true } },
+    },
+  })
+  if (!shift) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
   await prisma.shift.update({ where: { id }, data: { status: "cancelled" } })
-  return NextResponse.json({ success: true })
+
+  // Cascade-cancel active registrations and notify each volunteer.
+  let notified = 0
+  for (const reg of shift.registrations) {
+    await prisma.registration.update({
+      where: { id: reg.id },
+      data: { status: "cancelled" },
+    })
+    const result = await sendNotification({
+      kind: "shift_cancelled",
+      recipient: { email: reg.volunteer.email, name: reg.volunteer.firstName },
+      data: {
+        volunteerName: reg.volunteer.firstName,
+        eventTitle: shift.event.title,
+        eventSlug: shift.event.slug,
+        shiftLabel: shift.label,
+        shiftDate: fmtDate(shift.date),
+      },
+    })
+    if (result.ok) notified++
+  }
+
+  return NextResponse.json({ success: true, cancelledRegistrations: shift.registrations.length, notified })
 }

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { sendNotification } from "@/lib/notifications"
+import type { NotificationKind } from "@/lib/notifications"
+
+export const dynamic = "force-dynamic"
+
+// Auth: any caller must present `Authorization: Bearer <CRON_SECRET>`.
+// In dev, if CRON_SECRET is unset we allow localhost requests so a manual
+// `curl http://localhost:3000/api/cron/reminders` works for testing.
+function isAuthorized(req: Request): boolean {
+  const expected = process.env.CRON_SECRET
+  const auth = req.headers.get("authorization")
+  if (expected) {
+    return auth === `Bearer ${expected}`
+  }
+  // No secret configured → only allow on localhost (dev mode).
+  const host = req.headers.get("host") ?? ""
+  return host.startsWith("localhost") || host.startsWith("127.0.0.1")
+}
+
+type Window = { kind: NotificationKind; field: "reminderJ2Sent" | "reminderJ1Sent" | "reminderDdSent"; minHours: number; maxHours: number }
+
+const WINDOWS: Window[] = [
+  { kind: "reminder_j2", field: "reminderJ2Sent", minHours: 47, maxHours: 49 },
+  { kind: "reminder_j1", field: "reminderJ1Sent", minHours: 23, maxHours: 25 },
+  { kind: "reminder_dd", field: "reminderDdSent", minHours: 2,  maxHours: 4 },
+]
+
+/**
+ * Combines a Shift.date (calendar day) with its startTime ("HH:MM") into
+ * a real timestamp. Stored times are local strings; we treat them as UTC
+ * which is fine for relative windows.
+ */
+function shiftStartAt(date: Date, startTime: string): Date {
+  const [h, m] = startTime.split(":").map(Number)
+  const d = new Date(date)
+  d.setUTCHours(h ?? 0, m ?? 0, 0, 0)
+  return d
+}
+
+export async function GET(req: Request) {
+  return run(req)
+}
+
+export async function POST(req: Request) {
+  return run(req)
+}
+
+async function run(req: Request) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const now = new Date()
+  const totals: Record<string, { eligible: number; sent: number; failed: number }> = {}
+
+  for (const win of WINDOWS) {
+    const lower = new Date(now.getTime() + win.minHours * 3600 * 1000)
+    const upper = new Date(now.getTime() + win.maxHours * 3600 * 1000)
+
+    // Pull every active registration that has not received this reminder
+    // yet AND whose shift starts inside the [lower, upper] window. The
+    // window is computed on the candidate set in JS (cheap with index +
+    // status filter).
+    const candidates = await prisma.registration.findMany({
+      where: {
+        status: "active",
+        [win.field]: null,
+        event: { remindersEnabled: true, publicStatus: "published" },
+        shift: { status: { not: "cancelled" } },
+      },
+      include: {
+        volunteer: true,
+        shift: true,
+        event: { include: { organization: { select: { name: true } } } },
+      },
+    })
+
+    const inWindow = candidates.filter((r) => {
+      const start = shiftStartAt(r.shift.date, r.shift.startTime)
+      return start >= lower && start <= upper
+    })
+
+    let sent = 0
+    let failed = 0
+    for (const r of inWindow) {
+      const start = shiftStartAt(r.shift.date, r.shift.startTime)
+      const result = await sendNotification({
+        kind: win.kind,
+        recipient: { email: r.volunteer.email, name: r.volunteer.firstName },
+        data: {
+          volunteerName: r.volunteer.firstName,
+          eventTitle: r.event.title,
+          organizationName: r.event.organization.name,
+          shiftLabel: r.shift.label,
+          shiftRoleName: r.shift.roleName,
+          shiftDate: r.shift.date.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" }),
+          shiftStart: r.shift.startTime,
+          shiftEnd: r.shift.endTime,
+          shiftLocation: r.shift.locationDetails,
+          editToken: r.editToken,
+          hoursUntil: Math.max(0, Math.round((start.getTime() - now.getTime()) / (3600 * 1000))),
+        },
+      })
+      if (result.ok) {
+        await prisma.registration.update({
+          where: { id: r.id },
+          data: { [win.field]: now },
+        })
+        sent++
+      } else {
+        failed++
+      }
+    }
+
+    totals[win.kind] = { eligible: inWindow.length, sent, failed }
+  }
+
+  return NextResponse.json({
+    runAt: now.toISOString(),
+    totals,
+  })
+}

--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -13,6 +13,7 @@ type EventFormData = {
   endDate: string
   publicInstructions: string
   confirmationMessage: string
+  reminderMessage: string
   publicStatus: "draft" | "published" | "archived"
 }
 
@@ -28,6 +29,7 @@ const defaultData: EventFormData = {
   endDate: "",
   publicInstructions: "",
   confirmationMessage: "Merci pour votre inscription ! À bientôt.",
+  reminderMessage: "",
   publicStatus: "draft",
 }
 
@@ -296,6 +298,15 @@ export default function EventForm({ initialData }: Props) {
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">Message de confirmation</label>
           <textarea rows={2} value={form.confirmationMessage} onChange={(e) => set("confirmationMessage", e.target.value)}
+            className={`${inputCls} resize-none`} />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Message de rappel <span className="text-gray-400 font-normal">(envoyé manuellement avant l&apos;événement)</span>
+          </label>
+          <textarea rows={3} value={form.reminderMessage} onChange={(e) => set("reminderMessage", e.target.value)}
+            placeholder="Consignes vestimentaires, point de RDV, accès, parking…"
             className={`${inputCls} resize-none`} />
         </div>
 

--- a/src/components/admin/MembersManager.tsx
+++ b/src/components/admin/MembersManager.tsx
@@ -21,7 +21,9 @@ type Props = {
 
 export default function MembersManager({ initialMembers, allTags }: Props) {
   const router = useRouter()
-  const [members, setMembers] = useState(initialMembers)
+  // No local state for members: derive from props directly so a
+  // router.refresh() (after import / deactivate) shows the new list.
+  const members = initialMembers
   const [search, setSearch] = useState("")
   const [tagFilter, setTagFilter] = useState<string>("")
   const [showInactive, setShowInactive] = useState(false)
@@ -51,9 +53,7 @@ export default function MembersManager({ initialMembers, allTags }: Props) {
   async function deactivate(id: string) {
     if (!confirm("Désactiver ce membre ?")) return
     const res = await fetch(`/api/admin/members/${id}`, { method: "DELETE" })
-    if (res.ok) {
-      setMembers((prev) => prev.map((m) => (m.id === id ? { ...m, active: false } : m)))
-    }
+    if (res.ok) refresh()
   }
 
   return (

--- a/src/components/admin/SendReminderButton.tsx
+++ b/src/components/admin/SendReminderButton.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+
+type Props = {
+  eventId: string
+  hasMessage: boolean
+  volunteerCount: number
+  lastSentAt: string | null
+}
+
+function formatRelative(iso: string): string {
+  const date = new Date(iso)
+  const diffMs = Date.now() - date.getTime()
+  const minutes = Math.floor(diffMs / 60_000)
+  if (minutes < 1) return "à l'instant"
+  if (minutes < 60) return `il y a ${minutes} min`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `il y a ${hours} h`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `il y a ${days} j`
+  return date.toLocaleDateString("fr-FR")
+}
+
+export default function SendReminderButton({ eventId, hasMessage, volunteerCount, lastSentAt }: Props) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<string | null>(null)
+  const [, startTransition] = useTransition()
+
+  const disabled = volunteerCount === 0
+
+  async function send() {
+    setSubmitting(true)
+    setResult(null)
+    const res = await fetch(`/api/admin/events/${eventId}/send-reminder`, { method: "POST" })
+    setSubmitting(false)
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setResult(typeof data?.error === "string" ? data.error : "Erreur lors de l'envoi")
+      return
+    }
+    const data = await res.json()
+    setResult(`${data.sent} rappel${data.sent > 1 ? "s" : ""} envoyé${data.sent > 1 ? "s" : ""}${data.failed ? ` · ${data.failed} échec${data.failed > 1 ? "s" : ""}` : ""}`)
+    startTransition(() => router.refresh())
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        className="bg-orange-600 text-white px-4 py-2 rounded-xl text-sm font-medium hover:bg-orange-700 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        📧 Envoyer le rappel ({volunteerCount} bénévole{volunteerCount > 1 ? "s" : ""})
+      </button>
+      {lastSentAt && (
+        <span className="text-xs text-gray-400">
+          Dernier envoi {formatRelative(lastSentAt)}
+        </span>
+      )}
+
+      {open && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4" onClick={() => setOpen(false)}>
+          <div className="bg-white rounded-2xl p-5 max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+            <h2 className="text-lg font-semibold text-gray-900 mb-3">Envoyer le rappel ?</h2>
+            <p className="text-sm text-gray-600 mb-4">
+              Un email sera envoyé à <strong>{volunteerCount} bénévole{volunteerCount > 1 ? "s" : ""}</strong>.
+              Chacun recevra ses créneaux et le message de rappel configuré dans l&apos;event.
+            </p>
+            {!hasMessage && (
+              <div className="bg-orange-50 border border-orange-200 rounded-lg p-3 text-xs text-orange-800 mb-4">
+                ⚠ Le message de rappel est vide. L&apos;email contiendra uniquement le récap des créneaux.
+                <br />
+                <a href={`/admin/events/${eventId}/edit`} className="underline">Ajouter un message</a>
+              </div>
+            )}
+            {result && (
+              <div className="bg-gray-50 rounded-lg p-3 text-sm text-gray-700 mb-4">{result}</div>
+            )}
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setOpen(false)} className="text-sm px-4 py-2 text-gray-600 hover:text-gray-900">
+                {result ? "Fermer" : "Annuler"}
+              </button>
+              {!result && (
+                <button
+                  onClick={send}
+                  disabled={submitting}
+                  className="bg-orange-600 text-white text-sm px-4 py-2 rounded-xl font-medium hover:bg-orange-700 disabled:opacity-50"
+                >
+                  {submitting ? "Envoi…" : "Envoyer"}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/__tests__/auth-guard.test.ts
+++ b/src/lib/__tests__/auth-guard.test.ts
@@ -5,9 +5,12 @@ const { authMock } = vi.hoisted(() => ({ authMock: vi.fn() }))
 
 vi.mock("@/auth", () => ({ auth: authMock }))
 
+const { firstOrgMock } = vi.hoisted(() => ({ firstOrgMock: vi.fn() }))
+
 vi.mock("../prisma", () => ({
   prisma: {
     $extends: () => ({ __scoped: true }),
+    organization: { findFirst: firstOrgMock },
   },
 }))
 
@@ -74,6 +77,7 @@ describe("requireSuperAdmin", () => {
 describe("getOrgContext (SSR helper)", () => {
   beforeEach(() => {
     authMock.mockReset()
+    firstOrgMock.mockReset()
   })
 
   it("returns null when not authenticated", async () => {
@@ -82,8 +86,23 @@ describe("getOrgContext (SSR helper)", () => {
     expect(result).toBeNull()
   })
 
-  it("returns null when user has no organizationId", async () => {
+  it("returns null when an org admin has no organizationId", async () => {
+    authMock.mockResolvedValue({ user: { role: "admin", organizationId: null } })
+    const result = await getOrgContext()
+    expect(result).toBeNull()
+  })
+
+  it("falls back to the first organization for a super_admin without org", async () => {
     authMock.mockResolvedValue({ user: { role: "super_admin", organizationId: null } })
+    firstOrgMock.mockResolvedValue({ id: "first-org" })
+    const result = await getOrgContext()
+    expect(result).not.toBeNull()
+    expect(result?.organizationId).toBe("first-org")
+  })
+
+  it("returns null for a super_admin if no organization exists yet", async () => {
+    authMock.mockResolvedValue({ user: { role: "super_admin", organizationId: null } })
+    firstOrgMock.mockResolvedValue(null)
     const result = await getOrgContext()
     expect(result).toBeNull()
   })

--- a/src/lib/__tests__/notifications.test.ts
+++ b/src/lib/__tests__/notifications.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest"
+import { render } from "../notifications/templates"
+
+describe("notification templates — render()", () => {
+  it("renders a registration confirmation with editToken in the link", () => {
+    const out = render({
+      kind: "registration_confirmation",
+      recipient: { email: "alice@example.com", name: "Alice" },
+      data: {
+        volunteerName: "Alice",
+        eventTitle: "Concert d'été",
+        shifts: [{ label: "Bar", date: "samedi 14 juin", startTime: "14:00", endTime: "18:00" }],
+        editToken: "tok-abc",
+      },
+    })
+    expect(out.subject).toContain("Concert d'été")
+    expect(out.html).toContain("/my/tok-abc")
+    expect(out.text).toContain("/my/tok-abc")
+    expect(out.text).toContain("Alice")
+  })
+
+  it("escapes HTML special chars in volunteer name", () => {
+    const out = render({
+      kind: "registration_confirmation",
+      recipient: { email: "x@y.com", name: "X" },
+      data: {
+        volunteerName: "<script>alert(1)</script>",
+        eventTitle: "Test",
+        shifts: [],
+        editToken: "tok",
+      },
+    })
+    expect(out.html).not.toContain("<script>alert(1)</script>")
+    expect(out.html).toContain("&lt;script&gt;")
+  })
+
+  it("escapes HTML in member invite custom message", () => {
+    const out = render({
+      kind: "member_invite",
+      recipient: { email: "m@x.com", name: "M" },
+      data: {
+        memberName: "Marie",
+        organizationName: "École",
+        eventTitle: "Spectacle",
+        eventDate: "14 juin",
+        eventLocation: "Salle A",
+        eventSlug: "spectacle",
+        message: '<img src=x onerror="alert(1)">',
+        token: "t1",
+      },
+    })
+    expect(out.html).not.toContain('onerror="alert')
+    expect(out.html).toContain("&lt;img")
+  })
+
+  it("renders reminder J-2 with shift details", () => {
+    const out = render({
+      kind: "reminder_j2",
+      recipient: { email: "a@x.com" },
+      data: {
+        volunteerName: "Alice",
+        eventTitle: "Concert",
+        organizationName: "Asso",
+        shiftLabel: "Buvette",
+        shiftRoleName: "Bar",
+        shiftDate: "samedi 14 juin",
+        shiftStart: "14:00",
+        shiftEnd: "18:00",
+        shiftLocation: "Salle des fêtes",
+        editToken: "tok",
+      },
+    })
+    expect(out.subject).toContain("J-2")
+    expect(out.text).toContain("Salle des fêtes")
+    expect(out.text).toContain("14:00")
+    expect(out.text).toContain("/my/tok")
+  })
+
+  it("renders reminder day-of with hoursUntil", () => {
+    const out = render({
+      kind: "reminder_dd",
+      recipient: { email: "a@x.com" },
+      data: {
+        volunteerName: "Alice",
+        eventTitle: "Concert",
+        organizationName: "Asso",
+        shiftLabel: "Buvette",
+        shiftRoleName: "Bar",
+        shiftDate: "samedi 14 juin",
+        shiftStart: "14:00",
+        shiftEnd: "18:00",
+        shiftLocation: null,
+        editToken: "tok",
+        hoursUntil: 3,
+      },
+    })
+    expect(out.subject).toContain("aujourd'hui")
+    expect(out.html).toContain("dans 3h")
+  })
+
+  it("renders manual reminder with custom message + multiple shifts", () => {
+    const out = render({
+      kind: "manual_reminder",
+      recipient: { email: "v@x.com" },
+      data: {
+        volunteerName: "Bob",
+        organizationName: "Asso",
+        eventTitle: "Concert",
+        customMessage: "Tenue noire SVP, RDV entrée artistes.",
+        shifts: [
+          { label: "Bar", date: "samedi 14", startTime: "14:00", endTime: "18:00", roleName: "Bar" },
+          { label: "Démontage", date: "samedi 14", startTime: "22:00", endTime: "00:00", roleName: "Démontage" },
+        ],
+        editToken: "tok",
+      },
+    })
+    expect(out.text).toContain("Tenue noire")
+    expect(out.text).toContain("Bar")
+    expect(out.text).toContain("Démontage")
+    expect(out.subject).toContain("Rappel")
+  })
+
+  it("renders shift modified with old vs new schedule", () => {
+    const out = render({
+      kind: "shift_modified",
+      recipient: { email: "v@x.com" },
+      data: {
+        volunteerName: "Bob",
+        eventTitle: "Concert",
+        shiftLabel: "Bar",
+        oldDate: "samedi 14",
+        newDate: "dimanche 15",
+        oldStart: "14:00",
+        newStart: "15:00",
+        oldEnd: "18:00",
+        newEnd: "19:00",
+        editToken: "tok",
+      },
+    })
+    expect(out.html).toContain("samedi 14")
+    expect(out.html).toContain("dimanche 15")
+    expect(out.html).toContain("15:00")
+    expect(out.subject).toContain("Changement")
+  })
+
+  it("renders shift cancelled with link back to event", () => {
+    const out = render({
+      kind: "shift_cancelled",
+      recipient: { email: "v@x.com" },
+      data: {
+        volunteerName: "Bob",
+        eventTitle: "Concert",
+        eventSlug: "concert-2026",
+        shiftLabel: "Bar",
+        shiftDate: "samedi 14",
+      },
+    })
+    expect(out.html).toContain("/events/concert-2026")
+    expect(out.subject).toContain("annulé")
+  })
+})

--- a/src/lib/auth-guard.ts
+++ b/src/lib/auth-guard.ts
@@ -57,13 +57,30 @@ export async function requireSuperAdmin() {
 
 /**
  * SSR variant for Server Components. Returns the org-scoped client or
- * `null` when the caller is not attached to an organization. Pages should
- * `redirect()` or call `notFound()` based on the result.
+ * `null` when the caller is not authenticated. Pages should `redirect()`
+ * or call `notFound()` based on the result.
+ *
+ * Super admins (no organizationId in their JWT) are silently routed to
+ * the first organization in the database so they can use the regular
+ * /admin/* pages without bouncing back to the login page. A proper
+ * /super-admin UI with an org switcher is on the roadmap (issue #35);
+ * until then this acts as the impersonation default.
  */
 export async function getOrgContext() {
   const session = await auth()
-  const organizationId = session?.user?.organizationId
-  if (!session?.user || !organizationId) return null
+  if (!session?.user) return null
+
+  let organizationId = session.user.organizationId
+  if (!organizationId && session.user.role === "super_admin") {
+    const fallback = await prisma.organization.findFirst({
+      orderBy: { createdAt: "asc" },
+      select: { id: true },
+    })
+    if (!fallback) return null
+    organizationId = fallback.id
+  }
+  if (!organizationId) return null
+
   return {
     session,
     organizationId,

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,19 +1,10 @@
-import nodemailer from "nodemailer"
+/**
+ * Thin wrappers kept for backwards compatibility with existing call
+ * sites. New code should call `sendNotification` from `./notifications`
+ * directly.
+ */
 
-const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"
-
-function createTransport() {
-  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD, SMTP_SECURE } = process.env
-
-  if (!SMTP_HOST || !SMTP_USER || !SMTP_PASSWORD) return null
-
-  return nodemailer.createTransport({
-    host: SMTP_HOST,
-    port: Number(SMTP_PORT ?? 587),
-    secure: SMTP_SECURE === "true",
-    auth: { user: SMTP_USER, pass: SMTP_PASSWORD },
-  })
-}
+import { sendNotification } from "./notifications"
 
 type RegistrationEmailData = {
   to: string
@@ -24,39 +15,15 @@ type RegistrationEmailData = {
 }
 
 export async function sendConfirmationEmail(data: RegistrationEmailData) {
-  const editUrl = `${appUrl}/my/${data.editToken}`
-  const from = process.env.EMAIL_FROM ?? "no-reply@example.com"
-
-  const html = `
-    <div style="font-family:sans-serif;max-width:520px;margin:0 auto;color:#111">
-      <h2>Merci pour votre inscription, ${data.volunteerName} !</h2>
-      <p>Vous êtes inscrit(e) aux créneaux suivants pour <strong>${data.eventTitle}</strong> :</p>
-      <ul style="padding-left:1.2em;line-height:1.8">
-        ${data.shifts.map((s) => `<li><strong>${s.label}</strong> — ${s.date} de ${s.startTime} à ${s.endTime}</li>`).join("")}
-      </ul>
-      <p style="margin-top:1.5em">
-        <a href="${editUrl}" style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;display:inline-block">
-          Voir / annuler mes inscriptions
-        </a>
-      </p>
-      <p style="color:#888;font-size:0.85em;margin-top:2em">Merci pour votre aide précieuse !</p>
-    </div>
-  `
-
-  const transport = createTransport()
-
-  if (!transport) {
-    console.log("[EMAIL - pas de SMTP configuré]")
-    console.log(`To: ${data.to} | Sujet: Confirmation — ${data.eventTitle}`)
-    console.log(`Lien d'édition : ${editUrl}`)
-    return
-  }
-
-  await transport.sendMail({
-    from,
-    to: data.to,
-    subject: `Confirmation d'inscription — ${data.eventTitle}`,
-    html,
+  await sendNotification({
+    kind: "registration_confirmation",
+    recipient: { email: data.to, name: data.volunteerName },
+    data: {
+      volunteerName: data.volunteerName,
+      eventTitle: data.eventTitle,
+      shifts: data.shifts,
+      editToken: data.editToken,
+    },
   })
 }
 
@@ -73,49 +40,20 @@ type MemberInviteEmailData = {
 }
 
 export async function sendMemberInvite(data: MemberInviteEmailData) {
-  const inviteUrl = `${appUrl}/events/${data.eventSlug}?token=${data.token}`
-  const from = process.env.EMAIL_FROM ?? "no-reply@example.com"
-
-  const html = `
-    <div style="font-family:sans-serif;max-width:520px;margin:0 auto;color:#111">
-      <h2>Bonjour ${data.memberName},</h2>
-      <p>${data.organizationName} a besoin de toi pour <strong>${data.eventTitle}</strong>.</p>
-      ${data.message ? `<p style="background:#f3f4f6;padding:12px;border-radius:8px;margin:16px 0">${escapeHtml(data.message)}</p>` : ""}
-      <p>
-        📅 ${data.eventDate}
-        ${data.eventLocation ? `<br>📍 ${data.eventLocation}` : ""}
-      </p>
-      <p style="margin-top:1.5em">
-        <a href="${inviteUrl}" style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;display:inline-block">
-          Voir les missions et m'inscrire
-        </a>
-      </p>
-      <p style="color:#888;font-size:0.85em;margin-top:2em">Si tu ne peux pas, ignore cet email. Merci !</p>
-    </div>
-  `
-
-  const transport = createTransport()
-  if (!transport) {
-    console.log("[EMAIL - pas de SMTP configuré]")
-    console.log(`To: ${data.to} | Sujet: [${data.organizationName}] On a besoin de toi pour ${data.eventTitle}`)
-    console.log(`Lien : ${inviteUrl}`)
-    return
-  }
-
-  await transport.sendMail({
-    from,
-    to: data.to,
-    subject: `[${data.organizationName}] On a besoin de toi pour ${data.eventTitle}`,
-    html,
+  await sendNotification({
+    kind: "member_invite",
+    recipient: { email: data.to, name: data.memberName },
+    data: {
+      memberName: data.memberName,
+      organizationName: data.organizationName,
+      eventTitle: data.eventTitle,
+      eventDate: data.eventDate,
+      eventLocation: data.eventLocation,
+      eventSlug: data.eventSlug,
+      message: data.message,
+      token: data.token,
+    },
   })
-}
-
-function escapeHtml(s: string) {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
 }
 
 export async function sendAdminNotification(data: {
@@ -126,19 +64,9 @@ export async function sendAdminNotification(data: {
 }) {
   const adminEmail = process.env.ADMIN_NOTIFICATION_EMAIL
   if (!adminEmail) return
-
-  const transport = createTransport()
-  if (!transport) return
-
-  const from = process.env.EMAIL_FROM ?? "no-reply@example.com"
-
-  await transport.sendMail({
-    from,
-    to: adminEmail,
-    subject: `Nouvelle inscription — ${data.eventTitle}`,
-    html: `
-      <p><strong>${data.volunteerName}</strong> (${data.volunteerEmail}) vient de s'inscrire à <strong>${data.eventTitle}</strong>.</p>
-      <p>Créneaux : ${data.shifts.map((s) => s.label).join(", ")}</p>
-    `,
+  await sendNotification({
+    kind: "admin_notification",
+    recipient: { email: adminEmail, name: "Admin" },
+    data,
   })
 }

--- a/src/lib/notifications/channels/email.ts
+++ b/src/lib/notifications/channels/email.ts
@@ -16,6 +16,11 @@ function createTransport() {
     // Mailpit accepts unauth'd connections; nodemailer needs the auth
     // object to be omitted in that case.
     auth: SMTP_USER && SMTP_PASSWORD ? { user: SMTP_USER, pass: SMTP_PASSWORD } : undefined,
+    // Hard fail fast when SMTP is unreachable so the route doesn't
+    // hang for 30s+ per recipient on a misconfigured port.
+    connectionTimeout: 5_000,
+    greetingTimeout: 5_000,
+    socketTimeout: 10_000,
   })
 }
 

--- a/src/lib/notifications/channels/email.ts
+++ b/src/lib/notifications/channels/email.ts
@@ -1,0 +1,49 @@
+import nodemailer from "nodemailer"
+import type {
+  NotificationChannelImpl,
+  NotificationPayload,
+} from "../types"
+import { render } from "../templates"
+
+function createTransport() {
+  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD, SMTP_SECURE } = process.env
+  if (!SMTP_HOST) return null
+
+  return nodemailer.createTransport({
+    host: SMTP_HOST,
+    port: Number(SMTP_PORT ?? 587),
+    secure: SMTP_SECURE === "true",
+    // Mailpit accepts unauth'd connections; nodemailer needs the auth
+    // object to be omitted in that case.
+    auth: SMTP_USER && SMTP_PASSWORD ? { user: SMTP_USER, pass: SMTP_PASSWORD } : undefined,
+  })
+}
+
+export const emailChannel: NotificationChannelImpl = {
+  name: "email",
+
+  async send(payload: NotificationPayload) {
+    const to = payload.recipient.email
+    if (!to) {
+      return { ok: false as const, reason: "recipient has no email" }
+    }
+
+    const { subject, html, text } = render(payload)
+    const from = process.env.EMAIL_FROM ?? "Bénévoles <no-reply@example.com>"
+    const transport = createTransport()
+
+    if (!transport) {
+      console.log(`[notif:email→${to}] ${subject}`)
+      console.log(`[notif:body]\n${text}\n`)
+      return { ok: true as const }
+    }
+
+    try {
+      await transport.sendMail({ from, to, subject, html, text })
+      return { ok: true as const }
+    } catch (err) {
+      console.error(`[notif:email→${to}] failed:`, err)
+      return { ok: false as const, reason: String(err) }
+    }
+  },
+}

--- a/src/lib/notifications/index.ts
+++ b/src/lib/notifications/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Public API of the notifications layer.
+ *
+ *   await sendNotification({ kind: "registration_confirmation", recipient, data })
+ *
+ * The default channel is email. Future channels (sms, whatsapp) plug
+ * in by adding an entry to `channels` below — no caller change needed.
+ */
+
+import { emailChannel } from "./channels/email"
+import type {
+  NotificationChannel,
+  NotificationChannelImpl,
+  NotificationKind,
+  NotificationPayload,
+} from "./types"
+
+const channels: Record<NotificationChannel, NotificationChannelImpl | null> = {
+  email: emailChannel,
+  sms: null, // TODO: post-MVP
+  whatsapp: null, // TODO: post-MVP
+}
+
+export async function sendNotification(
+  payload: NotificationPayload,
+  channel: NotificationChannel = "email",
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const impl = channels[channel]
+  if (!impl) return { ok: false, reason: `channel ${channel} not implemented` }
+  return impl.send(payload)
+}
+
+export type { NotificationKind, NotificationChannel, NotificationPayload }

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -1,0 +1,381 @@
+/**
+ * Templates for every notification kind. Plain-text + HTML.
+ * Keep them short and transactional — the platform is NOT a mailing tool.
+ */
+
+import type { NotificationPayload } from "./types"
+
+const APP_URL = (process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000").replace(/\/$/, "")
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+function btn(href: string, label: string): string {
+  return `<a href="${href}" style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;display:inline-block;font-weight:600">${label}</a>`
+}
+
+function wrap(inner: string): string {
+  return `<div style="font-family:-apple-system,system-ui,sans-serif;max-width:520px;margin:0 auto;color:#111;line-height:1.5">${inner}</div>`
+}
+
+export type RenderedEmail = {
+  subject: string
+  html: string
+  text: string
+}
+
+export function render(payload: NotificationPayload): RenderedEmail {
+  switch (payload.kind) {
+    case "registration_confirmation":
+      return renderConfirmation(payload)
+    case "member_invite":
+      return renderMemberInvite(payload)
+    case "reminder_j2":
+      return renderReminderJ2(payload)
+    case "reminder_j1":
+      return renderReminderJ1(payload)
+    case "reminder_dd":
+      return renderReminderDd(payload)
+    case "manual_reminder":
+      return renderManualReminder(payload)
+    case "shift_modified":
+      return renderShiftModified(payload)
+    case "shift_cancelled":
+      return renderShiftCancelled(payload)
+    case "registration_cancelled":
+      return renderRegistrationCancelled(payload)
+    case "admin_notification":
+      return renderAdminNotification(payload)
+  }
+}
+
+// ── Inscription confirmée ────────────────────────────────────────────────────
+
+function renderConfirmation(p: NotificationPayload): RenderedEmail {
+  const { volunteerName, eventTitle, shifts, editToken } = p.data as {
+    volunteerName: string
+    eventTitle: string
+    shifts: { label: string; date: string; startTime: string; endTime: string }[]
+    editToken: string
+  }
+  const editUrl = `${APP_URL}/my/${editToken}`
+  const subject = `Confirmation d'inscription — ${eventTitle}`
+
+  const text = [
+    `Merci ${volunteerName} !`,
+    ``,
+    `Vous êtes inscrit·e pour ${eventTitle} :`,
+    ...shifts.map((s) => `  • ${s.label} — ${s.date} de ${s.startTime} à ${s.endTime}`),
+    ``,
+    `Voir / annuler vos inscriptions : ${editUrl}`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Merci pour votre inscription, ${escapeHtml(volunteerName)} !</h2>
+    <p>Vous êtes inscrit·e pour <strong>${escapeHtml(eventTitle)}</strong> :</p>
+    <ul style="padding-left:1.2em">
+      ${shifts.map((s) => `<li><strong>${escapeHtml(s.label)}</strong> — ${escapeHtml(s.date)} de ${escapeHtml(s.startTime)} à ${escapeHtml(s.endTime)}</li>`).join("")}
+    </ul>
+    <p style="margin-top:1.5em">${btn(editUrl, "Voir / annuler mes inscriptions")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Invitation d'un membre ───────────────────────────────────────────────────
+
+function renderMemberInvite(p: NotificationPayload): RenderedEmail {
+  const {
+    memberName,
+    organizationName,
+    eventTitle,
+    eventDate,
+    eventLocation,
+    eventSlug,
+    message,
+    token,
+  } = p.data as {
+    memberName: string
+    organizationName: string
+    eventTitle: string
+    eventDate: string
+    eventLocation: string | null
+    eventSlug: string
+    message: string | null
+    token: string
+  }
+  const inviteUrl = `${APP_URL}/events/${eventSlug}?token=${token}`
+  const subject = `[${organizationName}] On a besoin de toi pour ${eventTitle}`
+
+  const text = [
+    `Bonjour ${memberName},`,
+    ``,
+    `${organizationName} a besoin de toi pour ${eventTitle}.`,
+    message ? `\n${message}\n` : ``,
+    `📅 ${eventDate}`,
+    eventLocation ? `📍 ${eventLocation}` : ``,
+    ``,
+    `Voir les missions : ${inviteUrl}`,
+  ].filter(Boolean).join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Bonjour ${escapeHtml(memberName)},</h2>
+    <p>${escapeHtml(organizationName)} a besoin de toi pour <strong>${escapeHtml(eventTitle)}</strong>.</p>
+    ${message ? `<p style="background:#f3f4f6;padding:12px;border-radius:8px">${escapeHtml(message)}</p>` : ""}
+    <p>📅 ${escapeHtml(eventDate)}${eventLocation ? `<br>📍 ${escapeHtml(eventLocation)}` : ""}</p>
+    <p style="margin-top:1.5em">${btn(inviteUrl, "Voir les missions et m'inscrire")}</p>
+    <p style="color:#888;font-size:0.85em;margin-top:2em">Si tu ne peux pas, ignore cet email.</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Rappels auto ─────────────────────────────────────────────────────────────
+
+type ReminderData = {
+  volunteerName: string
+  eventTitle: string
+  organizationName: string
+  shiftLabel: string
+  shiftRoleName: string
+  shiftDate: string
+  shiftStart: string
+  shiftEnd: string
+  shiftLocation: string | null
+  editToken: string
+  hoursUntil?: number
+}
+
+function renderReminderJ2(p: NotificationPayload): RenderedEmail {
+  const d = p.data as ReminderData
+  const editUrl = `${APP_URL}/my/${d.editToken}`
+  const subject = `J-2 — ${d.eventTitle}`
+
+  const text = [
+    `Bonjour ${d.volunteerName},`,
+    ``,
+    `Tu es inscrit·e pour ${d.eventTitle} dans 2 jours :`,
+    `📅 ${d.shiftDate}`,
+    `🕐 ${d.shiftStart} - ${d.shiftEnd}`,
+    d.shiftLocation ? `📍 ${d.shiftLocation}` : ``,
+    `Mission : ${d.shiftRoleName}`,
+    ``,
+    `Si tu ne peux plus venir, merci de nous prévenir : ${editUrl}`,
+  ].filter(Boolean).join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Plus que 2 jours !</h2>
+    <p>Bonjour ${escapeHtml(d.volunteerName)}, on se retrouve bientôt pour <strong>${escapeHtml(d.eventTitle)}</strong> :</p>
+    <ul style="padding-left:1.2em;line-height:1.8">
+      <li>📅 ${escapeHtml(d.shiftDate)}</li>
+      <li>🕐 ${escapeHtml(d.shiftStart)} – ${escapeHtml(d.shiftEnd)}</li>
+      ${d.shiftLocation ? `<li>📍 ${escapeHtml(d.shiftLocation)}</li>` : ""}
+      <li>Mission : <strong>${escapeHtml(d.shiftRoleName)}</strong></li>
+    </ul>
+    <p style="margin-top:1.5em">${btn(editUrl, "Annuler si je ne peux plus venir")}</p>
+    <p style="color:#888;font-size:0.85em">À très vite,<br>${escapeHtml(d.organizationName)}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+function renderReminderJ1(p: NotificationPayload): RenderedEmail {
+  const d = p.data as ReminderData
+  const editUrl = `${APP_URL}/my/${d.editToken}`
+  const subject = `Demain — ${d.eventTitle}`
+
+  const text = `Plus que 24h ! ${d.eventTitle} demain à ${d.shiftStart}${d.shiftLocation ? `, à ${d.shiftLocation}` : ""}.\nTu fais : ${d.shiftRoleName}\n\n${editUrl}`
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Plus que 24h !</h2>
+    <p><strong>${escapeHtml(d.eventTitle)}</strong> demain à ${escapeHtml(d.shiftStart)}${d.shiftLocation ? `, à ${escapeHtml(d.shiftLocation)}` : ""}.</p>
+    <p>Tu fais : <strong>${escapeHtml(d.shiftRoleName)}</strong></p>
+    <p style="margin-top:1.5em">${btn(editUrl, "Gérer mon inscription")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+function renderReminderDd(p: NotificationPayload): RenderedEmail {
+  const d = p.data as ReminderData
+  const editUrl = `${APP_URL}/my/${d.editToken}`
+  const subject = `C'est aujourd'hui — ${d.eventTitle}`
+  const hoursLabel = d.hoursUntil && d.hoursUntil > 0 ? `dans ${d.hoursUntil}h` : "très bientôt"
+
+  const text = `RDV ${hoursLabel} ! ${d.shiftLocation ?? ""} à ${d.shiftStart}\n\n${editUrl}`
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">RDV ${hoursLabel} !</h2>
+    ${d.shiftLocation ? `<p>📍 ${escapeHtml(d.shiftLocation)}</p>` : ""}
+    <p>🕐 ${escapeHtml(d.shiftStart)}</p>
+    <p>Mission : <strong>${escapeHtml(d.shiftRoleName)}</strong></p>
+    <p style="margin-top:1.5em">${btn(editUrl, "Voir mon inscription")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Rappel manuel J-7 ────────────────────────────────────────────────────────
+
+function renderManualReminder(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    volunteerName: string
+    organizationName: string
+    eventTitle: string
+    customMessage: string
+    shifts: { label: string; date: string; startTime: string; endTime: string; roleName: string }[]
+    editToken: string
+  }
+  const editUrl = `${APP_URL}/my/${d.editToken}`
+  const subject = `Rappel — ${d.eventTitle}`
+
+  const text = [
+    `Bonjour ${d.volunteerName},`,
+    ``,
+    d.customMessage,
+    ``,
+    `Vos créneaux pour ${d.eventTitle} :`,
+    ...d.shifts.map((s) => `  • ${s.date} · ${s.label} · ${s.startTime}–${s.endTime}`),
+    ``,
+    `Gérer vos inscriptions : ${editUrl}`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Bonjour ${escapeHtml(d.volunteerName)},</h2>
+    ${d.customMessage ? `<div style="background:#f3f4f6;padding:14px;border-radius:8px;white-space:pre-wrap">${escapeHtml(d.customMessage)}</div>` : ""}
+    <p style="margin-top:1.5em">Vos créneaux pour <strong>${escapeHtml(d.eventTitle)}</strong> :</p>
+    <ul style="padding-left:1.2em;line-height:1.8">
+      ${d.shifts.map((s) => `<li>${escapeHtml(s.date)} · <strong>${escapeHtml(s.label)}</strong> · ${escapeHtml(s.startTime)}–${escapeHtml(s.endTime)}</li>`).join("")}
+    </ul>
+    <p style="margin-top:1.5em">${btn(editUrl, "Gérer mes inscriptions")}</p>
+    <p style="color:#888;font-size:0.85em">${escapeHtml(d.organizationName)}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Notif modification d'un shift ────────────────────────────────────────────
+
+function renderShiftModified(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    volunteerName: string
+    eventTitle: string
+    shiftLabel: string
+    oldDate: string
+    newDate: string
+    oldStart: string
+    newStart: string
+    oldEnd: string
+    newEnd: string
+    editToken: string
+  }
+  const editUrl = `${APP_URL}/my/${d.editToken}`
+  const subject = `Changement d'horaire — ${d.eventTitle}`
+
+  const text = [
+    `Bonjour ${d.volunteerName},`,
+    ``,
+    `Le créneau "${d.shiftLabel}" pour ${d.eventTitle} a changé :`,
+    `Avant : ${d.oldDate} de ${d.oldStart} à ${d.oldEnd}`,
+    `Maintenant : ${d.newDate} de ${d.newStart} à ${d.newEnd}`,
+    ``,
+    `Si ces nouveaux horaires ne te conviennent pas : ${editUrl}`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Changement d'horaire</h2>
+    <p>Bonjour ${escapeHtml(d.volunteerName)}, le créneau <strong>${escapeHtml(d.shiftLabel)}</strong> pour <strong>${escapeHtml(d.eventTitle)}</strong> a été modifié :</p>
+    <p><span style="text-decoration:line-through;color:#999">${escapeHtml(d.oldDate)} · ${escapeHtml(d.oldStart)}–${escapeHtml(d.oldEnd)}</span></p>
+    <p style="font-weight:600">${escapeHtml(d.newDate)} · ${escapeHtml(d.newStart)}–${escapeHtml(d.newEnd)}</p>
+    <p style="margin-top:1.5em">${btn(editUrl, "Gérer mon inscription")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Notif annulation d'un shift ──────────────────────────────────────────────
+
+function renderShiftCancelled(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    volunteerName: string
+    eventTitle: string
+    eventSlug: string
+    shiftLabel: string
+    shiftDate: string
+  }
+  const eventUrl = `${APP_URL}/events/${d.eventSlug}`
+  const subject = `Créneau annulé — ${d.eventTitle}`
+
+  const text = [
+    `Bonjour ${d.volunteerName},`,
+    ``,
+    `Le créneau "${d.shiftLabel}" du ${d.shiftDate} a été annulé.`,
+    ``,
+    `Tu peux te réinscrire sur un autre créneau : ${eventUrl}`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Créneau annulé</h2>
+    <p>Bonjour ${escapeHtml(d.volunteerName)},</p>
+    <p>Le créneau <strong>${escapeHtml(d.shiftLabel)}</strong> du ${escapeHtml(d.shiftDate)} pour <strong>${escapeHtml(d.eventTitle)}</strong> a été annulé.</p>
+    <p style="margin-top:1.5em">${btn(eventUrl, "Voir les autres créneaux")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Inscription annulée (suite à #46 cancel public) ──────────────────────────
+
+function renderRegistrationCancelled(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    volunteerName: string
+    eventTitle: string
+    eventSlug: string
+    shiftLabel: string
+  }
+  const eventUrl = `${APP_URL}/events/${d.eventSlug}`
+  const subject = `Désinscription — ${d.eventTitle}`
+
+  const text = [
+    `Bonjour ${d.volunteerName},`,
+    ``,
+    `Ta désinscription du créneau "${d.shiftLabel}" pour ${d.eventTitle} est confirmée.`,
+    ``,
+    `Si tu changes d'avis : ${eventUrl}`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Désinscription confirmée</h2>
+    <p>Bonjour ${escapeHtml(d.volunteerName)},</p>
+    <p>Ta désinscription du créneau <strong>${escapeHtml(d.shiftLabel)}</strong> pour <strong>${escapeHtml(d.eventTitle)}</strong> est bien prise en compte.</p>
+    <p style="margin-top:1.5em">${btn(eventUrl, "Voir les créneaux disponibles")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Notif admin (interne) ────────────────────────────────────────────────────
+
+function renderAdminNotification(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    eventTitle: string
+    volunteerName: string
+    volunteerEmail: string
+    shifts: { label: string }[]
+  }
+  const subject = `Nouvelle inscription — ${d.eventTitle}`
+
+  const text = `${d.volunteerName} (${d.volunteerEmail}) vient de s'inscrire à ${d.eventTitle}.\nCréneaux : ${d.shifts.map((s) => s.label).join(", ")}`
+
+  const html = `
+    <p><strong>${escapeHtml(d.volunteerName)}</strong> (${escapeHtml(d.volunteerEmail)}) vient de s'inscrire à <strong>${escapeHtml(d.eventTitle)}</strong>.</p>
+    <p>Créneaux : ${d.shifts.map((s) => escapeHtml(s.label)).join(", ")}</p>
+  `
+
+  return { subject, html, text }
+}

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Notifications layer.
+ *
+ * Goal: keep the rest of the app provider-agnostic. Code calls
+ * `sendNotification(payload)` and never imports nodemailer / resend
+ * / twilio directly. Adding a new channel (SMS, WhatsApp) becomes a
+ * matter of adding one file under `channels/` without touching callers.
+ */
+
+export type NotificationChannel = "email" | "sms" | "whatsapp"
+
+export type NotificationKind =
+  | "registration_confirmation"
+  | "member_invite"
+  | "reminder_j2"
+  | "reminder_j1"
+  | "reminder_dd"
+  | "manual_reminder"
+  | "shift_modified"
+  | "shift_cancelled"
+  | "registration_cancelled"
+  | "admin_notification"
+
+export type Recipient = {
+  email?: string | null
+  phone?: string | null
+  name?: string
+}
+
+/**
+ * Payload of any notification. `data` carries the kind-specific
+ * variables consumed by the template. The shape is loose on purpose:
+ * each template knows its own contract.
+ */
+export type NotificationPayload<K extends NotificationKind = NotificationKind> = {
+  kind: K
+  recipient: Recipient
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: Record<string, any>
+}
+
+export interface NotificationChannelImpl {
+  readonly name: NotificationChannel
+  send(payload: NotificationPayload): Promise<{ ok: true } | { ok: false; reason: string }>
+}


### PR DESCRIPTION
## Summary

Sprint 3 of the SaaS work. Completes the MVP with a notification abstraction layer + the 3 event communication features.

> ⚠️ This branch contains Sprint 1 and Sprint 2 commits. Merge Sprints 1 and 2 first for a clean diff.

## Changes

**Notifications layer (#53)**
- `src/lib/notifications/{types,index,templates}.ts` + `channels/email.ts`
- Code calls `sendNotification({ kind, recipient, data })` and never imports nodemailer directly again
- 10 transactional kinds with HTML + text templates, systematic HTML escaping
- `src/lib/email.ts` kept as a backwards-compatible wrapper

**Confirmation + cancellation (#46)**
- Already covered by existing `/my/[token]` — issue closed in milestone tracking

**Event communications (#51)**
- Schema: `Event.reminderMessage / reminderSentAt / remindersEnabled` + `Registration.reminderJ2Sent / J1Sent / DdSent` + 3 composite indexes
- Migration `20260427180000_communications`
- `/api/cron/reminders` (GET/POST) authenticated with `Bearer CRON_SECRET` (or localhost in dev). Sends D-2 / D-1 / day-of within windows `[47-49h]` / `[23-25h]` / `[2-4h]`, idempotent via `reminderXSent` stamps.
- `/api/admin/events/[id]/send-reminder`: manual D-7 reminder. 1 email per volunteer, deduplicated by `volunteerId`. Updates `Event.reminderSentAt`.
- `EventForm`: new "Reminder message" textarea.
- Event detail page: new "Communications" section with `SendReminderButton` (confirmation modal, warning if message empty, last send shown as relative time).
- `PATCH /api/admin/shifts/[id]`: detects schedule changes and emails registered volunteers if `notifyVolunteers !== false`.
- `DELETE /api/admin/shifts/[id]`: cancels registrations + emails each volunteer.

**Admin invitations view (#52)**
- Already delivered in Sprint 2 (`InvitationsManager`) — issue closed

**Tests**
- `src/lib/__tests__/notifications.test.ts`: 8 tests covering each kind + HTML escaping of user inputs
- 88 tests pass (was 80). `tsc` + `eslint` clean.

## Cron configuration

- **Vercel**: add a Cron Jobs entry (`*/60 * * * *` → `/api/cron/reminders`) with `CRON_SECRET` as an env variable
- **Self-hosted Docker**: `crontab -e` → `0 * * * * curl -H "Authorization: Bearer $CRON_SECRET" https://app/api/cron/reminders`

## Test plan

- [ ] `prisma migrate deploy` applies the communications migration
- [ ] Create a registration whose shift starts in ~48h, hit `/api/cron/reminders` → D-2 email received in Mailpit
- [ ] Hit again → no duplicate send (idempotency)
- [ ] Click "Send reminder" on an event with registrations → 1 email per volunteer with their shifts
- [ ] Modify a shift's schedule with registered volunteers → notification emails received
- [ ] Delete a shift → registrations cancelled + emails received
- [ ] `npm test` passes (88 tests)

## Issues

Closes #46 #51 #52 #53

---
_Generated by [Claude Code](https://claude.ai/code/session_017XAA7o12GpsXpUeyGNynZH)_