### PR TITLE
feat(saas): Sprint 4 — Multi-admin + Super admin UI + Password reset

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,40 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Variables prêtes à l'emploi pour développer en local avec Docker.
+#
+#   cp .env.development.example .env
+#   make dev-up
+#   make dev-setup     # installe deps, applique migrations, seed
+#   make dev           # npm run dev
+#
+# Les valeurs ci-dessous correspondent aux services exposés par
+# docker-compose.dev.yml. Ne PAS utiliser ces credentials en production.
+# ──────────────────────────────────────────────────────────────────────────────
+
+# PostgreSQL (docker-compose.dev.yml)
+DATABASE_URL="postgresql://benevoles:benevoles@localhost:5432/benevoles?schema=public"
+
+# Compte super admin créé par `npm run db:seed`
+ADMIN_EMAIL="admin@local"
+ADMIN_PASSWORD="admin"
+
+# NextAuth — généré par `make dev-setup` si laissé vide
+AUTH_SECRET=""
+
+# SMTP local via Mailpit (docker-compose.dev.yml)
+# Lecture des emails capturés sur http://localhost:8025
+SMTP_HOST="localhost"
+SMTP_PORT="1025"
+SMTP_SECURE="false"
+SMTP_USER="dev"
+SMTP_PASSWORD="dev"
+EMAIL_FROM="Bénévoles <no-reply@local>"
+
+# (Optionnel) Adresse qui reçoit une copie à chaque inscription
+ADMIN_NOTIFICATION_EMAIL=""
+
+# URL publique de l'app (utilisée dans les emails)
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+
+# NextAuth derrière un reverse proxy → laissé tel quel en dev
+AUTH_URL="http://localhost:3000"
+AUTH_TRUST_HOST="true"

--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,13 @@ dev-down: ## Stoppe la stack dev
 dev-logs: ## Suit les logs des services dev
 	docker compose -f docker-compose.dev.yml logs -f
 
-dev-reset: ## ⚠ Supprime la DB locale (volume) et redémarre tout
+dev-reset: ## ⚠ Supprime la DB locale (volume) et redémarre tout (deps + migrations + seed)
+	@$(MAKE) install
 	docker compose -f docker-compose.dev.yml down -v
 	docker compose -f docker-compose.dev.yml up -d
 	@echo "→ Attente de PostgreSQL…"
 	@until docker exec benevoles_postgres_dev pg_isready -U benevoles >/dev/null 2>&1; do sleep 0.5; done
+	@$(MAKE) db-generate
 	@$(MAKE) db-migrate
 	@$(MAKE) db-seed
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,88 @@
+# Bénévoles — tâches de développement.
+# Usage : `make` (équivalent à `make help`).
+
+.PHONY: help dev dev-up dev-down dev-logs dev-reset dev-setup db-migrate db-seed db-studio test lint typecheck install
+
+DEFAULT_GOAL := help
+
+# ── Aide ─────────────────────────────────────────────────────────────────────
+
+help: ## Affiche cette aide
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+# ── Setup initial ─────────────────────────────────────────────────────────────
+
+dev-setup: ## Setup complet : .env, deps, postgres, migrations, seed
+	@if [ ! -f .env ]; then \
+		echo "→ Copie .env.development.example → .env"; \
+		cp .env.development.example .env; \
+	fi
+	@if ! grep -q '^AUTH_SECRET=".\+"' .env; then \
+		SECRET=$$(openssl rand -base64 48 | tr -d '\n='); \
+		if [ "$$(uname)" = "Darwin" ]; then \
+			sed -i '' "s|^AUTH_SECRET=.*|AUTH_SECRET=\"$$SECRET\"|" .env; \
+		else \
+			sed -i "s|^AUTH_SECRET=.*|AUTH_SECRET=\"$$SECRET\"|" .env; \
+		fi; \
+		echo "→ AUTH_SECRET généré"; \
+	fi
+	@$(MAKE) install
+	@$(MAKE) dev-up
+	@echo "→ Attente de PostgreSQL…"
+	@until docker exec benevoles_postgres_dev pg_isready -U benevoles >/dev/null 2>&1; do sleep 0.5; done
+	@$(MAKE) db-migrate
+	@$(MAKE) db-seed
+	@echo ""
+	@echo "✅ Prêt ! Lance \`make dev\` pour démarrer le serveur."
+	@echo "   • App :     http://localhost:3000"
+	@echo "   • Admin :   http://localhost:3000/admin"
+	@echo "   • Mailpit : http://localhost:8025"
+
+install: ## Installe les dépendances npm
+	npm install --legacy-peer-deps
+
+# ── Stack docker ──────────────────────────────────────────────────────────────
+
+dev-up: ## Démarre postgres + mailpit (docker-compose.dev.yml)
+	docker compose -f docker-compose.dev.yml up -d
+
+dev-down: ## Stoppe la stack dev
+	docker compose -f docker-compose.dev.yml down
+
+dev-logs: ## Suit les logs des services dev
+	docker compose -f docker-compose.dev.yml logs -f
+
+dev-reset: ## ⚠ Supprime la DB locale (volume) et redémarre tout
+	docker compose -f docker-compose.dev.yml down -v
+	docker compose -f docker-compose.dev.yml up -d
+	@echo "→ Attente de PostgreSQL…"
+	@until docker exec benevoles_postgres_dev pg_isready -U benevoles >/dev/null 2>&1; do sleep 0.5; done
+	@$(MAKE) db-migrate
+	@$(MAKE) db-seed
+
+# ── App ───────────────────────────────────────────────────────────────────────
+
+dev: ## Lance le serveur Next.js en dev
+	npm run dev
+
+# ── Base de données ──────────────────────────────────────────────────────────
+
+db-migrate: ## Applique les migrations Prisma
+	npx prisma migrate deploy
+
+db-seed: ## Crée le compte admin + données démo
+	npm run db:seed
+
+db-studio: ## Ouvre Prisma Studio (http://localhost:5555)
+	npm run db:studio
+
+# ── Qualité ──────────────────────────────────────────────────────────────────
+
+test: ## Lance la suite de tests (vitest)
+	npm test
+
+lint: ## Lint le code
+	npm run lint
+
+typecheck: ## Vérifie les types TypeScript
+	npx tsc --noEmit

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Bénévoles — tâches de développement.
 # Usage : `make` (équivalent à `make help`).
 
-.PHONY: help dev dev-up dev-down dev-logs dev-reset dev-setup db-migrate db-seed db-studio test lint typecheck install
+.PHONY: help dev dev-up dev-down dev-logs dev-reset dev-setup db-generate db-migrate db-seed db-studio test lint typecheck install
 
 DEFAULT_GOAL := help
 
@@ -27,6 +27,7 @@ dev-setup: ## Setup complet : .env, deps, postgres, migrations, seed
 		echo "→ AUTH_SECRET généré"; \
 	fi
 	@$(MAKE) install
+	@$(MAKE) db-generate
 	@$(MAKE) dev-up
 	@echo "→ Attente de PostgreSQL…"
 	@until docker exec benevoles_postgres_dev pg_isready -U benevoles >/dev/null 2>&1; do sleep 0.5; done
@@ -66,15 +67,20 @@ dev: ## Lance le serveur Next.js en dev
 	npm run dev
 
 # ── Base de données ──────────────────────────────────────────────────────────
+# Prisma 7 (avec prisma.config.ts) ne charge pas .env automatiquement.
+# Ces commandes utilisent --env-file pour le faire explicitement.
+
+db-generate: ## Génère le client Prisma (src/generated/prisma)
+	node --env-file=.env node_modules/.bin/prisma generate
 
 db-migrate: ## Applique les migrations Prisma
-	npx prisma migrate deploy
+	node --env-file=.env node_modules/.bin/prisma migrate deploy
 
 db-seed: ## Crée le compte admin + données démo
-	npm run db:seed
+	node --env-file=.env node_modules/.bin/prisma db seed
 
 db-studio: ## Ouvre Prisma Studio (http://localhost:5555)
-	npm run db:studio
+	node --env-file=.env node_modules/.bin/prisma studio
 
 # ── Qualité ──────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -42,34 +42,44 @@ Application de gestion de bénévoles pour événements. Les organisateurs crée
 ## Prérequis
 
 - Node.js **22** (`nvm use 22`)
-- PostgreSQL 16+
+- Docker (pour la stack dev locale)
 
-## Installation
+## Démarrage rapide (dev)
+
+Tout est piloté par le `Makefile`. Une seule commande pour partir de zéro :
 
 ```bash
 git clone <repo>
 cd benevoles
-npm install
-cp .env.example .env
-# Remplir .env (voir section Variables d'environnement)
+make dev-setup   # .env, npm install, docker (postgres + mailpit), migrations, seed
+make dev         # lance le serveur Next.js
 ```
 
-### Base de données
+Trois services exposés en dev :
+- App : http://localhost:3000 (admin sur `/admin`, identifiants par défaut `admin@local` / `admin`)
+- Mailpit : http://localhost:8025 (captures de tous les emails envoyés en dev)
+- Postgres : `localhost:5432` (`benevoles` / `benevoles`)
+
+| Commande | Effet |
+|----------|-------|
+| `make help` | Liste toutes les tâches |
+| `make dev` | `npm run dev` |
+| `make dev-up` / `dev-down` | Démarre / arrête postgres + mailpit |
+| `make dev-reset` | ⚠ Supprime la DB locale et la réinitialise |
+| `make db-migrate` / `db-seed` / `db-studio` | Tâches Prisma |
+| `make test` / `lint` / `typecheck` | Qualité |
+
+### Setup manuel (sans Make)
 
 ```bash
-# Créer les tables
-npm run db:migrate
-
-# Créer le compte admin (+ données de démonstration)
+docker compose -f docker-compose.dev.yml up -d
+npm install --legacy-peer-deps
+cp .env.development.example .env
+# Génère un AUTH_SECRET et colle-le dans .env
+openssl rand -base64 48
+npx prisma migrate deploy
 npm run db:seed
-```
-
-### Développement
-
-```bash
 npm run dev
-# → http://localhost:3000         (vue publique)
-# → http://localhost:3000/admin   (interface admin)
 ```
 
 ## Variables d'environnement

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,17 @@
-# Juste PostgreSQL — pour développer avec `npm run dev` en local
+# Stack de développement local — à utiliser avec `npm run dev`
+#
+#   make dev-up      # démarre postgres + mailpit
+#   make dev-down    # arrête tout
+#   make dev-logs    # suit les logs
+#   make dev-reset   # wipe la DB (⚠ destructif)
+#
+# Postgres expose le port 5432 (DATABASE_URL dans .env).
+# Mailpit expose deux ports : 1025 (SMTP) et 8025 (UI web pour lire les emails).
+
 services:
   postgres:
     image: postgres:16-alpine
+    container_name: benevoles_postgres_dev
     restart: unless-stopped
     environment:
       POSTGRES_DB: benevoles
@@ -16,6 +26,19 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+
+  # Mailpit : capture tous les emails envoyés en dev pour les inspecter
+  # dans une UI web sans envoyer de vraies notifications.
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: benevoles_mailpit_dev
+    restart: unless-stopped
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # UI web → http://localhost:8025
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
 
 volumes:
   postgres_dev_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
+        "@types/qrcode": "^1.5.6",
         "bcryptjs": "^3.0.3",
+        "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",
         "exceljs": "^4.4.0",
         "nanoid": "^5.1.9",
@@ -20,6 +22,7 @@
         "nodemailer": "^8.0.6",
         "pg": "^8.20.0",
         "prisma": "^7.8.0",
+        "qrcode": "^1.5.4",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "resend": "^6.12.2",
@@ -3100,6 +3103,15 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -3848,7 +3860,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4481,6 +4492,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001790",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
@@ -4601,11 +4621,85 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4618,7 +4712,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -4739,6 +4832,12 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
     },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
+    },
     "node_modules/csv-stringify": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
@@ -4839,6 +4938,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -4934,6 +5042,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -6154,6 +6268,15 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -8509,6 +8632,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -8545,7 +8677,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8709,6 +8840,15 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8991,6 +9131,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -9170,6 +9327,15 @@
         "url": "https://github.com/sponsors/remeda"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -9178,6 +9344,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resend": {
       "version": "6.12.2",
@@ -9460,6 +9632,12 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -10890,6 +11068,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -11019,6 +11203,12 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -11038,6 +11228,143 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   "dependencies": {
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "@types/qrcode": "^1.5.6",
     "bcryptjs": "^3.0.3",
+    "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",
     "exceljs": "^4.4.0",
     "nanoid": "^5.1.9",
@@ -33,6 +35,7 @@
     "nodemailer": "^8.0.6",
     "pg": "^8.20.0",
     "prisma": "^7.8.0",
+    "qrcode": "^1.5.4",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "resend": "^6.12.2",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
-    seed: "tsx ./prisma/seed.ts",
+    seed: "./node_modules/.bin/tsx ./prisma/seed.ts",
   },
   datasource: {
     url: process.env["DATABASE_URL"],

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
+    seed: "tsx ./prisma/seed.ts",
   },
   datasource: {
     url: process.env["DATABASE_URL"],

--- a/prisma/migrations/20260427120000_multitenant_foundation/migration.sql
+++ b/prisma/migrations/20260427120000_multitenant_foundation/migration.sql
@@ -1,0 +1,93 @@
+-- ────────────────────────────────────────────────────────────────────────────
+-- Multi-tenant foundation
+--
+-- Adds Organization + Member, scopes Event and AdminUser to an organization.
+-- Existing data is migrated under a single "default" organization to keep
+-- the application working without manual intervention.
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- CreateTable
+CREATE TABLE "Organization" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Organization_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Organization_slug_key" ON "Organization"("slug");
+
+-- Seed the default organization so existing rows can reference it
+INSERT INTO "Organization" ("id", "name", "slug", "createdAt", "updatedAt")
+VALUES ('default', 'Organisation par défaut', 'default', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- CreateTable
+CREATE TABLE "Member" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "firstName" TEXT NOT NULL,
+    "lastName" TEXT NOT NULL,
+    "email" TEXT,
+    "phone" TEXT,
+    "tags" TEXT[],
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Member_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Member_organizationId_idx" ON "Member"("organizationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Member_organizationId_email_key" ON "Member"("organizationId", "email");
+
+-- AddForeignKey
+ALTER TABLE "Member" ADD CONSTRAINT "Member_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Event: scope to organization
+-- Adds organizationId (default 'default' to backfill existing rows), then
+-- removes the global slug uniqueness in favor of (organizationId, slug).
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE "Event" ADD COLUMN "organizationId" TEXT NOT NULL DEFAULT 'default';
+ALTER TABLE "Event" ALTER COLUMN "organizationId" DROP DEFAULT;
+
+DROP INDEX "Event_slug_key";
+
+CREATE INDEX "Event_organizationId_idx" ON "Event"("organizationId");
+CREATE UNIQUE INDEX "Event_organizationId_slug_key" ON "Event"("organizationId", "slug");
+
+ALTER TABLE "Event" ADD CONSTRAINT "Event_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- AdminUser: optional organizationId (NULL means super_admin / cross-tenant)
+-- Backfill: every existing admin that is not a super_admin is attached to
+-- the default organization.
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE "AdminUser" ADD COLUMN "organizationId" TEXT;
+
+UPDATE "AdminUser" SET "organizationId" = 'default' WHERE "role" <> 'super_admin';
+
+CREATE INDEX "AdminUser_organizationId_idx" ON "AdminUser"("organizationId");
+
+ALTER TABLE "AdminUser" ADD CONSTRAINT "AdminUser_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Volunteer: index email for fast lookups (used by future cross-event views)
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE INDEX "Volunteer_email_idx" ON "Volunteer"("email");

--- a/prisma/migrations/20260427150000_member_invites/migration.sql
+++ b/prisma/migrations/20260427150000_member_invites/migration.sql
@@ -1,0 +1,30 @@
+-- ────────────────────────────────────────────────────────────────────────────
+-- Member invites
+--
+-- Tokenised invitation a member receives by email for a given event.
+-- The token is what pre-fills the public registration form. Stays valid
+-- after first use so the volunteer can revisit/manage their registration.
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE "MemberInvite" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "memberId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "sentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "usedAt" TIMESTAMP(3),
+
+    CONSTRAINT "MemberInvite_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MemberInvite_token_key" ON "MemberInvite"("token");
+CREATE INDEX "MemberInvite_token_idx" ON "MemberInvite"("token");
+CREATE UNIQUE INDEX "MemberInvite_eventId_memberId_key" ON "MemberInvite"("eventId", "memberId");
+
+ALTER TABLE "MemberInvite" ADD CONSTRAINT "MemberInvite_eventId_fkey"
+    FOREIGN KEY ("eventId") REFERENCES "Event"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "MemberInvite" ADD CONSTRAINT "MemberInvite_memberId_fkey"
+    FOREIGN KEY ("memberId") REFERENCES "Member"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260427180000_communications/migration.sql
+++ b/prisma/migrations/20260427180000_communications/migration.sql
@@ -1,0 +1,28 @@
+-- ────────────────────────────────────────────────────────────────────────────
+-- Sprint 3 — Communications
+--
+-- Adds:
+--   • Event.reminderMessage / reminderSentAt / remindersEnabled (manual J-7)
+--   • Registration.reminderJ2Sent / J1Sent / DdSent (auto reminders idempotency)
+--   • indexes used by the cron job to avoid full table scans
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE "Event"
+  ADD COLUMN "reminderMessage"  TEXT,
+  ADD COLUMN "reminderSentAt"   TIMESTAMP(3),
+  ADD COLUMN "remindersEnabled" BOOLEAN NOT NULL DEFAULT true;
+
+ALTER TABLE "Registration"
+  ADD COLUMN "reminderJ2Sent" TIMESTAMP(3),
+  ADD COLUMN "reminderJ1Sent" TIMESTAMP(3),
+  ADD COLUMN "reminderDdSent" TIMESTAMP(3);
+
+-- Indexes used by /api/cron/reminders. Filtered queries hit
+-- (status, reminderXSent IS NULL) on every run, so a composite index
+-- on those two columns avoids scanning the whole table once volume grows.
+CREATE INDEX "Registration_status_reminderJ2Sent_idx"
+  ON "Registration"("status", "reminderJ2Sent");
+CREATE INDEX "Registration_status_reminderJ1Sent_idx"
+  ON "Registration"("status", "reminderJ1Sent");
+CREATE INDEX "Registration_status_reminderDdSent_idx"
+  ON "Registration"("status", "reminderDdSent");

--- a/prisma/migrations/20260430100000_admin_invitations/migration.sql
+++ b/prisma/migrations/20260430100000_admin_invitations/migration.sql
@@ -1,0 +1,59 @@
+-- ────────────────────────────────────────────────────────────────────────────
+-- Sprint 4 — Admin invitations + organization soft-delete + password reset
+--
+-- Adds:
+--   • Organization.isActive (soft-delete)
+--   • AdminInvitation (token-based admin invitations per org)
+--   • PasswordResetToken (forgot-password flow)
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE "Organization"
+  ADD COLUMN "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+CREATE TABLE "AdminInvitation" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "invitedBy" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'admin',
+    "token" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "acceptedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdminInvitation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "AdminInvitation_token_key" ON "AdminInvitation"("token");
+CREATE UNIQUE INDEX "AdminInvitation_email_organizationId_key"
+    ON "AdminInvitation"("email", "organizationId");
+CREATE INDEX "AdminInvitation_organizationId_idx" ON "AdminInvitation"("organizationId");
+CREATE INDEX "AdminInvitation_token_idx" ON "AdminInvitation"("token");
+
+ALTER TABLE "AdminInvitation" ADD CONSTRAINT "AdminInvitation_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AdminInvitation" ADD CONSTRAINT "AdminInvitation_invitedBy_fkey"
+    FOREIGN KEY ("invitedBy") REFERENCES "AdminUser"("id")
+    ON DELETE NO ACTION ON UPDATE CASCADE;
+
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PasswordResetToken_token_key" ON "PasswordResetToken"("token");
+CREATE INDEX "PasswordResetToken_token_idx" ON "PasswordResetToken"("token");
+CREATE INDEX "PasswordResetToken_userId_idx" ON "PasswordResetToken"("userId");
+
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "AdminUser"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,9 +7,22 @@ datasource db {
   provider = "postgresql"
 }
 
+model Organization {
+  id        String   @id @default(cuid())
+  name      String
+  slug      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  events  Event[]
+  members Member[]
+  admins  AdminUser[]
+}
+
 model Event {
   id                  String   @id @default(cuid())
-  slug                String   @unique
+  organizationId      String
+  slug                String
   title               String
   description         String?
   location            String?
@@ -22,8 +35,12 @@ model Event {
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 
+  organization  Organization   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   shifts        Shift[]
   registrations Registration[]
+
+  @@unique([organizationId, slug])
+  @@index([organizationId])
 }
 
 model Shift {
@@ -57,6 +74,8 @@ model Volunteer {
   updatedAt DateTime @updatedAt
 
   registrations Registration[]
+
+  @@index([email])
 }
 
 model Registration {
@@ -76,13 +95,37 @@ model Registration {
   volunteer Volunteer @relation(fields: [volunteerId], references: [id])
 }
 
+model Member {
+  id             String   @id @default(cuid())
+  organizationId String
+  firstName      String
+  lastName       String
+  email          String?
+  phone          String?
+  tags           String[]
+  active         Boolean  @default(true)
+  notes          String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([organizationId, email])
+  @@index([organizationId])
+}
+
 model AdminUser {
-  id           String   @id @default(cuid())
-  email        String   @unique
-  name         String
-  passwordHash String
-  role         String   @default("admin")
-  isActive     Boolean  @default(true)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id             String   @id @default(cuid())
+  organizationId String?
+  email          String   @unique
+  name           String
+  passwordHash   String
+  role           String   @default("admin")
+  isActive       Boolean  @default(true)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+
+  @@index([organizationId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,20 +20,23 @@ model Organization {
 }
 
 model Event {
-  id                  String   @id @default(cuid())
+  id                  String    @id @default(cuid())
   organizationId      String
   slug                String
   title               String
   description         String?
   location            String?
-  publicStatus        String   @default("draft")
+  publicStatus        String    @default("draft")
   startDate           DateTime
   endDate             DateTime
   publicInstructions  String?
   confirmationMessage String?
-  showSchedule        Json     @default("[]")
-  createdAt           DateTime @default(now())
-  updatedAt           DateTime @updatedAt
+  showSchedule        Json      @default("[]")
+  reminderMessage     String?
+  reminderSentAt      DateTime?
+  remindersEnabled    Boolean   @default(true)
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
   organization  Organization   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   shifts        Shift[]
@@ -80,20 +83,27 @@ model Volunteer {
 }
 
 model Registration {
-  id          String   @id @default(cuid())
-  eventId     String
-  shiftId     String
-  volunteerId String
-  status      String   @default("active")
-  source      String   @default("public_form")
-  comment     String?
-  editToken   String   @unique
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id             String    @id @default(cuid())
+  eventId        String
+  shiftId        String
+  volunteerId    String
+  status         String    @default("active")
+  source         String    @default("public_form")
+  comment        String?
+  editToken      String    @unique
+  reminderJ2Sent DateTime?
+  reminderJ1Sent DateTime?
+  reminderDdSent DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   event     Event     @relation(fields: [eventId], references: [id], onDelete: Cascade)
   shift     Shift     @relation(fields: [shiftId], references: [id], onDelete: Cascade)
   volunteer Volunteer @relation(fields: [volunteerId], references: [id])
+
+  @@index([status, reminderJ2Sent])
+  @@index([status, reminderJ1Sent])
+  @@index([status, reminderDdSent])
 }
 
 model Member {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,12 +11,14 @@ model Organization {
   id        String   @id @default(cuid())
   name      String
   slug      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  events  Event[]
-  members Member[]
-  admins  AdminUser[]
+  events      Event[]
+  members     Member[]
+  admins      AdminUser[]
+  invitations AdminInvitation[]
 }
 
 model Event {
@@ -152,7 +154,43 @@ model AdminUser {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  organization Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+  organization    Organization?        @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+  invitationsSent AdminInvitation[]    @relation("InvitedBy")
+  passwordResets  PasswordResetToken[]
 
   @@index([organizationId])
+}
+
+model AdminInvitation {
+  id             String    @id @default(cuid())
+  email          String
+  organizationId String
+  invitedBy      String
+  role           String    @default("admin")
+  token          String    @unique @default(cuid())
+  expiresAt      DateTime
+  acceptedAt     DateTime?
+  revokedAt      DateTime?
+  createdAt      DateTime  @default(now())
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  inviter      AdminUser    @relation("InvitedBy", fields: [invitedBy], references: [id])
+
+  @@unique([email, organizationId])
+  @@index([organizationId])
+  @@index([token])
+}
+
+model PasswordResetToken {
+  id        String    @id @default(cuid())
+  userId    String
+  token     String    @unique @default(cuid())
+  expiresAt DateTime
+  usedAt    DateTime?
+  createdAt DateTime  @default(now())
+
+  user AdminUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([token])
+  @@index([userId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Event {
   organization  Organization   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   shifts        Shift[]
   registrations Registration[]
+  memberInvites MemberInvite[]
 
   @@unique([organizationId, slug])
   @@index([organizationId])
@@ -108,10 +109,26 @@ model Member {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organization Organization   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  invites      MemberInvite[]
 
   @@unique([organizationId, email])
   @@index([organizationId])
+}
+
+model MemberInvite {
+  id       String    @id @default(cuid())
+  eventId  String
+  memberId String
+  token    String    @unique @default(cuid())
+  sentAt   DateTime  @default(now())
+  usedAt   DateTime?
+
+  event  Event  @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  member Member @relation(fields: [memberId], references: [id], onDelete: Cascade)
+
+  @@unique([eventId, memberId])
+  @@index([token])
 }
 
 model AdminUser {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,22 +6,55 @@ const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! })
 const prisma = new PrismaClient({ adapter })
 
 async function main() {
-  const email    = process.env.ADMIN_EMAIL    ?? "admin@localhost"
-  const password = process.env.ADMIN_PASSWORD ?? "change-me"
-  const passwordHash = await bcrypt.hash(password, 12)
+  const superAdminEmail    = process.env.ADMIN_EMAIL    ?? "admin@localhost"
+  const superAdminPassword = process.env.ADMIN_PASSWORD ?? "change-me"
+  const passwordHash       = await bcrypt.hash(superAdminPassword, 12)
 
-  await prisma.adminUser.upsert({
-    where: { email },
-    update: { passwordHash },
+  // Default organization (also used by the multi-tenant migration to backfill
+  // existing data; safe to upsert since the migration may already have created it).
+  const org = await prisma.organization.upsert({
+    where: { id: "default" },
+    update: {},
     create: {
-      email,
-      name: "Administrateur",
-      passwordHash,
-      role: "super_admin",
+      id: "default",
+      slug: "default",
+      name: "Organisation par défaut",
     },
   })
 
-  console.log(`✓ Admin créé : ${email}`)
+  // Super admin: not attached to any organization (cross-tenant role).
+  await prisma.adminUser.upsert({
+    where: { email: superAdminEmail },
+    update: { passwordHash, organizationId: null, role: "super_admin" },
+    create: {
+      email: superAdminEmail,
+      name: "Super Administrateur",
+      passwordHash,
+      role: "super_admin",
+      organizationId: null,
+    },
+  })
+
+  console.log(`✓ Super admin créé : ${superAdminEmail}`)
+
+  // Demo org admin so the default organization is usable out of the box.
+  const orgAdminEmail = process.env.ORG_ADMIN_EMAIL ?? "org-admin@localhost"
+  const orgAdminPassword = process.env.ORG_ADMIN_PASSWORD ?? superAdminPassword
+  const orgAdminHash = await bcrypt.hash(orgAdminPassword, 12)
+
+  await prisma.adminUser.upsert({
+    where: { email: orgAdminEmail },
+    update: { passwordHash: orgAdminHash, organizationId: org.id, role: "admin" },
+    create: {
+      email: orgAdminEmail,
+      name: "Administrateur (org par défaut)",
+      passwordHash: orgAdminHash,
+      role: "admin",
+      organizationId: org.id,
+    },
+  })
+
+  console.log(`✓ Admin d'org créé : ${orgAdminEmail} (org: ${org.slug})`)
 
   const demoShowSchedule = [
     { name: "Représentation samedi après-midi", date: "2026-06-14", startTime: "14:30", endTime: "16:00" },
@@ -30,9 +63,10 @@ async function main() {
   ]
 
   const event = await prisma.event.upsert({
-    where: { slug: "spectacle-cirque-2026" },
+    where: { organizationId_slug: { organizationId: org.id, slug: "spectacle-cirque-2026" } },
     update: { showSchedule: demoShowSchedule },
     create: {
+      organizationId: org.id,
       slug: "spectacle-cirque-2026",
       title: "Spectacle de Cirque 2026",
       description: "Le grand spectacle annuel de fin d'année.",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -36,6 +36,11 @@ async function main() {
       endDate: new Date("2026-06-15"),
       publicInstructions: "Merci pour votre aide ! Présentez-vous 15 minutes avant le début de votre créneau.",
       confirmationMessage: "Merci pour votre inscription ! Nous vous contacterons si besoin. À bientôt !",
+      showSchedule: [
+        { name: "Représentation samedi après-midi", date: "2026-06-14", startTime: "14:30", endTime: "16:00" },
+        { name: "Représentation samedi soir",       date: "2026-06-14", startTime: "20:00", endTime: "21:30" },
+        { name: "Représentation dimanche",          date: "2026-06-15", startTime: "14:30", endTime: "16:00" },
+      ],
     },
   })
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -23,9 +23,15 @@ async function main() {
 
   console.log(`✓ Admin créé : ${email}`)
 
+  const demoShowSchedule = [
+    { name: "Représentation samedi après-midi", date: "2026-06-14", startTime: "14:30", endTime: "16:00" },
+    { name: "Représentation samedi soir",       date: "2026-06-14", startTime: "20:00", endTime: "21:30" },
+    { name: "Représentation dimanche",          date: "2026-06-15", startTime: "14:30", endTime: "16:00" },
+  ]
+
   const event = await prisma.event.upsert({
     where: { slug: "spectacle-cirque-2026" },
-    update: {},
+    update: { showSchedule: demoShowSchedule },
     create: {
       slug: "spectacle-cirque-2026",
       title: "Spectacle de Cirque 2026",
@@ -36,11 +42,7 @@ async function main() {
       endDate: new Date("2026-06-15"),
       publicInstructions: "Merci pour votre aide ! Présentez-vous 15 minutes avant le début de votre créneau.",
       confirmationMessage: "Merci pour votre inscription ! Nous vous contacterons si besoin. À bientôt !",
-      showSchedule: [
-        { name: "Représentation samedi après-midi", date: "2026-06-14", startTime: "14:30", endTime: "16:00" },
-        { name: "Représentation samedi soir",       date: "2026-06-14", startTime: "20:00", endTime: "21:30" },
-        { name: "Représentation dimanche",          date: "2026-06-15", startTime: "14:30", endTime: "16:00" },
-      ],
+      showSchedule: demoShowSchedule,
     },
   })
 

--- a/src/app/admin/events/[id]/edit/page.tsx
+++ b/src/app/admin/events/[id]/edit/page.tsx
@@ -1,14 +1,18 @@
-import { notFound } from "next/navigation"
-import { prisma } from "@/lib/prisma"
+import { notFound, redirect } from "next/navigation"
+import { getOrgContext } from "@/lib/auth-guard"
 import EventForm from "@/components/admin/EventForm"
 import Link from "next/link"
 
 export const dynamic = "force-dynamic"
 
 export default async function EditEventPage({ params }: { params: Promise<{ id: string }> }) {
+  const ctx = await getOrgContext()
+  if (!ctx) redirect("/admin/login")
+  const { db } = ctx
+
   const { id } = await params
 
-  const event = await prisma.event.findUnique({ where: { id } })
+  const event = await db.event.findFirst({ where: { id } })
   if (!event) notFound()
 
   const initialData = {

--- a/src/app/admin/events/[id]/edit/page.tsx
+++ b/src/app/admin/events/[id]/edit/page.tsx
@@ -24,6 +24,7 @@ export default async function EditEventPage({ params }: { params: Promise<{ id: 
     endDate: event.endDate.toISOString().split("T")[0],
     publicInstructions: event.publicInstructions ?? "",
     confirmationMessage: event.confirmationMessage ?? "",
+    reminderMessage: event.reminderMessage ?? "",
     publicStatus: event.publicStatus as "draft" | "published" | "archived",
     showSchedule: (event.showSchedule ?? []) as Array<{ name: string; date: string; startTime: string; endTime: string }>,
   }

--- a/src/app/admin/events/[id]/invitations/page.tsx
+++ b/src/app/admin/events/[id]/invitations/page.tsx
@@ -1,0 +1,93 @@
+import { notFound, redirect } from "next/navigation"
+import Link from "next/link"
+import { getOrgContext } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import InvitationsManager from "@/components/admin/InvitationsManager"
+
+export const dynamic = "force-dynamic"
+
+export default async function EventInvitationsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const ctx = await getOrgContext()
+  if (!ctx) redirect("/admin/login")
+  const { db, organizationId } = ctx
+
+  const { id } = await params
+
+  const event = await db.event.findFirst({
+    where: { id },
+    select: { id: true, title: true, slug: true, startDate: true },
+  })
+  if (!event) notFound()
+
+  const [invites, members] = await Promise.all([
+    db.memberInvite.findMany({
+      where: { eventId: id },
+      include: {
+        member: { select: { id: true, firstName: true, lastName: true, email: true, tags: true, active: true } },
+      },
+      orderBy: { sentAt: "desc" },
+    }),
+    db.member.findMany({
+      where: { active: true },
+      orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    }),
+  ])
+
+  const memberEmails = invites
+    .map((i) => i.member.email)
+    .filter((e): e is string => !!e)
+
+  const registrations = memberEmails.length
+    ? await prisma.registration.findMany({
+        where: {
+          eventId: id,
+          status: "active",
+          volunteer: { email: { in: memberEmails } },
+          // Defense in depth: ensure the registration belongs to this org
+          // even if someone bypasses the helper's where injection.
+          event: { organizationId },
+        },
+        select: { volunteer: { select: { email: true } } },
+      })
+    : []
+  const registeredEmails = new Set(registrations.map((r) => r.volunteer.email))
+
+  const allTags = new Set<string>()
+  for (const m of members) for (const t of m.tags) allTags.add(t)
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <Link href={`/admin/events/${id}`} className="text-sm text-blue-600">← {event.title}</Link>
+        <h1 className="text-xl font-bold text-gray-900 mt-1">Invitations</h1>
+      </div>
+
+      <InvitationsManager
+        eventId={id}
+        members={members.map((m) => ({
+          id: m.id,
+          firstName: m.firstName,
+          lastName: m.lastName,
+          email: m.email,
+          tags: m.tags,
+        }))}
+        allTags={Array.from(allTags).sort()}
+        invites={invites.map((i) => ({
+          id: i.id,
+          sentAt: i.sentAt.toISOString(),
+          usedAt: i.usedAt?.toISOString() ?? null,
+          memberId: i.member.id,
+          firstName: i.member.firstName,
+          lastName: i.member.lastName,
+          email: i.member.email,
+          tags: i.member.tags,
+          registered: i.member.email ? registeredEmails.has(i.member.email) : false,
+        }))}
+      />
+    </div>
+  )
+}

--- a/src/app/admin/events/[id]/page.tsx
+++ b/src/app/admin/events/[id]/page.tsx
@@ -81,6 +81,18 @@ export default async function AdminEventPage({ params }: { params: Promise<{ id:
         >
           Voir les inscriptions
         </Link>
+        <Link
+          href={`/admin/events/${event.id}/invitations`}
+          className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors flex-1 text-center"
+        >
+          Inviter des membres
+        </Link>
+        <Link
+          href={`/admin/events/${event.id}/qr`}
+          className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors flex-1 text-center"
+        >
+          QR code
+        </Link>
         <a
           href={`/api/admin/events/${event.id}/export`}
           className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors flex-1 text-center"

--- a/src/app/admin/events/[id]/page.tsx
+++ b/src/app/admin/events/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getOrgContext } from "@/lib/auth-guard"
 import { formatShortDate } from "@/lib/utils"
 import StatusBadge from "@/components/admin/StatusBadge"
 import PublishToggle from "@/components/admin/PublishToggle"
+import SendReminderButton from "@/components/admin/SendReminderButton"
 
 export const dynamic = "force-dynamic"
 
@@ -30,6 +31,10 @@ export default async function AdminEventPage({ params }: { params: Promise<{ id:
   const totalCapacity = event.shifts.reduce((s, sh) => s + sh.capacity, 0)
   const totalRegistered = event.shifts.reduce((s, sh) => s + sh.registrations.length, 0)
   const criticalShifts = event.shifts.filter((sh) => sh.capacity - sh.registrations.length >= 2)
+
+  // Unique volunteers across all shifts (one reminder email per person)
+  const uniqueVolunteerIds = new Set<string>()
+  for (const sh of event.shifts) for (const r of sh.registrations) uniqueVolunteerIds.add(r.volunteerId)
 
   return (
     <div className="space-y-6">
@@ -106,6 +111,16 @@ export default async function AdminEventPage({ params }: { params: Promise<{ id:
         >
           Exporter PDF ↗
         </a>
+      </div>
+
+      <div className="border-t border-gray-200 pt-4">
+        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Communications</h2>
+        <SendReminderButton
+          eventId={event.id}
+          hasMessage={!!event.reminderMessage?.trim()}
+          volunteerCount={uniqueVolunteerIds.size}
+          lastSentAt={event.reminderSentAt?.toISOString() ?? null}
+        />
       </div>
 
       {criticalShifts.length > 0 && (

--- a/src/app/admin/events/[id]/page.tsx
+++ b/src/app/admin/events/[id]/page.tsx
@@ -1,6 +1,6 @@
-import { notFound } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
 import Link from "next/link"
-import { prisma } from "@/lib/prisma"
+import { getOrgContext } from "@/lib/auth-guard"
 import { formatShortDate } from "@/lib/utils"
 import StatusBadge from "@/components/admin/StatusBadge"
 import PublishToggle from "@/components/admin/PublishToggle"
@@ -8,9 +8,13 @@ import PublishToggle from "@/components/admin/PublishToggle"
 export const dynamic = "force-dynamic"
 
 export default async function AdminEventPage({ params }: { params: Promise<{ id: string }> }) {
+  const ctx = await getOrgContext()
+  if (!ctx) redirect("/admin/login")
+  const { db } = ctx
+
   const { id } = await params
 
-  const event = await prisma.event.findUnique({
+  const event = await db.event.findFirst({
     where: { id },
     include: {
       shifts: {

--- a/src/app/admin/events/[id]/qr/page.tsx
+++ b/src/app/admin/events/[id]/qr/page.tsx
@@ -1,0 +1,39 @@
+import { notFound, redirect } from "next/navigation"
+import { getOrgContext } from "@/lib/auth-guard"
+import { env } from "@/lib/env"
+import QrPrintView from "@/components/admin/QrPrintView"
+
+export const dynamic = "force-dynamic"
+
+export default async function EventQrPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const ctx = await getOrgContext()
+  if (!ctx) redirect("/admin/login")
+  const { db } = ctx
+
+  const { id } = await params
+
+  const event = await db.event.findFirst({
+    where: { id },
+    select: { id: true, slug: true, title: true, location: true, startDate: true, endDate: true },
+  })
+  if (!event) notFound()
+
+  const baseUrl = (env.NEXT_PUBLIC_APP_URL ?? "").replace(/\/$/, "") || ""
+  const publicUrl = baseUrl ? `${baseUrl}/events/${event.slug}` : `/events/${event.slug}`
+
+  return (
+    <QrPrintView
+      eventId={event.id}
+      title={event.title}
+      location={event.location}
+      startDate={event.startDate.toISOString()}
+      endDate={event.endDate.toISOString()}
+      publicUrl={publicUrl}
+      backHref={`/admin/events/${event.id}`}
+    />
+  )
+}

--- a/src/app/admin/events/[id]/registrations/page.tsx
+++ b/src/app/admin/events/[id]/registrations/page.tsx
@@ -1,6 +1,6 @@
-import { notFound } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
 import Link from "next/link"
-import { prisma } from "@/lib/prisma"
+import { getOrgContext } from "@/lib/auth-guard"
 import RegistrationsManager from "@/components/admin/RegistrationsManager"
 
 export const dynamic = "force-dynamic"
@@ -12,10 +12,14 @@ export default async function RegistrationsPage({
   params: Promise<{ id: string }>
   searchParams: Promise<{ shift?: string }>
 }) {
+  const ctx = await getOrgContext()
+  if (!ctx) redirect("/admin/login")
+  const { db } = ctx
+
   const { id } = await params
   const { shift: initialShiftFilter } = await searchParams
 
-  const event = await prisma.event.findUnique({
+  const event = await db.event.findFirst({
     where: { id },
     include: {
       shifts: {

--- a/src/app/admin/events/[id]/shifts/page.tsx
+++ b/src/app/admin/events/[id]/shifts/page.tsx
@@ -1,14 +1,18 @@
-import { notFound } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
 import Link from "next/link"
-import { prisma } from "@/lib/prisma"
+import { getOrgContext } from "@/lib/auth-guard"
 import ShiftsManager from "@/components/admin/ShiftsManager"
 
 export const dynamic = "force-dynamic"
 
 export default async function ShiftsPage({ params }: { params: Promise<{ id: string }> }) {
+  const ctx = await getOrgContext()
+  if (!ctx) redirect("/admin/login")
+  const { db } = ctx
+
   const { id } = await params
 
-  const event = await prisma.event.findUnique({
+  const event = await db.event.findFirst({
     where: { id },
     include: {
       shifts: {

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
-import { prisma } from "@/lib/prisma"
+import { redirect } from "next/navigation"
+import { getOrgContext } from "@/lib/auth-guard"
 import { formatShortDate } from "@/lib/utils"
 import DuplicateButton from "@/components/admin/DuplicateButton"
 import StatusBadge from "@/components/admin/StatusBadge"
@@ -7,7 +8,11 @@ import StatusBadge from "@/components/admin/StatusBadge"
 export const dynamic = "force-dynamic"
 
 export default async function AdminEventsPage() {
-  const events = await prisma.event.findMany({
+  const ctx = await getOrgContext()
+  if (!ctx) redirect("/admin/login")
+  const { db } = ctx
+
+  const events = await db.event.findMany({
     include: {
       shifts: {
         where: { status: { not: "cancelled" } },

--- a/src/app/admin/forgot-password/page.tsx
+++ b/src/app/admin/forgot-password/page.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [done, setDone] = useState(false)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    await fetch("/api/public/forgot-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    })
+    setSubmitting(false)
+    setDone(true)
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4 py-8">
+      <div className="bg-white rounded-2xl border border-gray-200 p-6 max-w-md w-full">
+        <h1 className="text-xl font-bold text-gray-900 mb-2">Mot de passe oublié</h1>
+        {done ? (
+          <>
+            <p className="text-sm text-gray-600 mb-4">
+              Si un compte existe avec cet email, un lien de réinitialisation a été envoyé.
+            </p>
+            <p className="text-sm text-gray-500 mb-6">Le lien est valable 1 heure.</p>
+            <Link href="/admin/login" className="text-sm text-blue-600">← Retour à la connexion</Link>
+          </>
+        ) : (
+          <form onSubmit={submit} className="space-y-4">
+            <p className="text-sm text-gray-600">
+              Entre ton email — on t&apos;envoie un lien pour choisir un nouveau mot de passe.
+            </p>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="ton@email.dev"
+              className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full bg-blue-600 text-white rounded-2xl py-3 text-sm font-semibold hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? "Envoi…" : "Envoyer le lien"}
+            </button>
+            <Link href="/admin/login" className="block text-sm text-blue-600 text-center">← Retour à la connexion</Link>
+          </form>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -10,7 +10,10 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <AdminNav userName={session.user?.name ?? "Admin"} />
+      <AdminNav
+        userName={session.user?.name ?? "Admin"}
+        isSuperAdmin={session.user?.role === "super_admin"}
+      />
       <main className="max-w-5xl mx-auto px-4 py-6">{children}</main>
     </div>
   )

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -77,6 +77,12 @@ export default function LoginPage() {
           >
             {loading ? "Connexion…" : "Se connecter"}
           </button>
+
+          <div className="text-center pt-2">
+            <a href="/admin/forgot-password" className="text-xs text-gray-500 hover:text-gray-800">
+              Mot de passe oublié ?
+            </a>
+          </div>
         </form>
       </div>
     </main>

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -1,0 +1,38 @@
+import { redirect } from "next/navigation"
+import { getOrgContext } from "@/lib/auth-guard"
+import MembersManager from "@/components/admin/MembersManager"
+
+export const dynamic = "force-dynamic"
+
+export default async function MembersPage() {
+  const ctx = await getOrgContext()
+  if (!ctx) redirect("/admin/login")
+  const { db } = ctx
+
+  const [members, allTags] = await Promise.all([
+    db.member.findMany({
+      orderBy: [{ active: "desc" }, { lastName: "asc" }, { firstName: "asc" }],
+    }),
+    db.member.findMany({ select: { tags: true } }).then((rows) => {
+      const set = new Set<string>()
+      for (const r of rows) for (const t of r.tags) set.add(t)
+      return Array.from(set).sort()
+    }),
+  ])
+
+  return (
+    <MembersManager
+      initialMembers={members.map((m) => ({
+        id: m.id,
+        firstName: m.firstName,
+        lastName: m.lastName,
+        email: m.email,
+        phone: m.phone,
+        tags: m.tags,
+        active: m.active,
+        notes: m.notes,
+      }))}
+      allTags={allTags}
+    />
+  )
+}

--- a/src/app/admin/reset-password/[token]/page.tsx
+++ b/src/app/admin/reset-password/[token]/page.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import Link from "next/link"
+
+export default function ResetPasswordPage() {
+  const params = useParams()
+  const router = useRouter()
+  const token = params.token as string
+
+  const [email, setEmail] = useState<string | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    fetch(`/api/public/reset-password/${token}`)
+      .then(async (r) => {
+        const data = await r.json().catch(() => ({}))
+        if (r.ok) setEmail(data.email)
+        else setLoadError(data.error ?? "Lien invalide")
+      })
+      .finally(() => setLoading(false))
+  }, [token])
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    if (password !== confirm) {
+      setError("Les mots de passe ne correspondent pas")
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    const res = await fetch(`/api/public/reset-password/${token}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+    })
+    setSubmitting(false)
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setError(typeof data?.error === "string" ? data.error : "Erreur")
+      return
+    }
+    setSuccess(true)
+    setTimeout(() => router.push("/admin/login"), 1500)
+  }
+
+  if (loading) return <Center>Chargement…</Center>
+
+  if (loadError) {
+    return (
+      <Center>
+        <h1 className="text-lg font-semibold text-gray-700 mb-2">Lien invalide</h1>
+        <p className="text-sm text-gray-500 mb-6">{loadError}</p>
+        <Link href="/admin/forgot-password" className="text-blue-600 text-sm">Demander un nouveau lien</Link>
+      </Center>
+    )
+  }
+
+  if (success) {
+    return (
+      <Center>
+        <h1 className="text-lg font-semibold text-green-700 mb-2">Mot de passe mis à jour</h1>
+        <p className="text-sm text-gray-500">Redirection vers la connexion…</p>
+      </Center>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4 py-8">
+      <div className="bg-white rounded-2xl border border-gray-200 p-6 max-w-md w-full">
+        <h1 className="text-xl font-bold text-gray-900 mb-2">Nouveau mot de passe</h1>
+        <p className="text-sm text-gray-600 mb-6">Compte : <strong>{email}</strong></p>
+
+        <form onSubmit={submit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Mot de passe *</label>
+            <input
+              type="password"
+              required
+              minLength={8}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <p className="text-xs text-gray-500 mt-1">8 caractères minimum.</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Confirmer *</label>
+            <input
+              type="password"
+              required
+              minLength={8}
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {error && <div className="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700">{error}</div>}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full bg-blue-600 text-white rounded-2xl py-3 text-sm font-semibold hover:bg-blue-700 disabled:opacity-50"
+          >
+            {submitting ? "Enregistrement…" : "Mettre à jour"}
+          </button>
+        </form>
+      </div>
+    </main>
+  )
+}
+
+function Center({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="bg-white rounded-2xl border border-gray-200 p-8 text-center max-w-md w-full">
+        {children}
+      </div>
+    </main>
+  )
+}

--- a/src/app/admin/settings/members/page.tsx
+++ b/src/app/admin/settings/members/page.tsx
@@ -1,0 +1,52 @@
+import { redirect } from "next/navigation"
+import { getOrgContext } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import TeamManager from "@/components/admin/TeamManager"
+
+export const dynamic = "force-dynamic"
+
+function daysUntil(target: Date, now: number): number {
+  return Math.max(0, Math.ceil((target.getTime() - now) / (24 * 3600 * 1000)))
+}
+
+export default async function TeamPage() {
+  const ctx = await getOrgContext()
+  if (!ctx) redirect("/admin/login")
+  const { organizationId, session } = ctx
+
+  // SSR component, evaluated once per request — Date.now() is fine here.
+  // eslint-disable-next-line react-hooks/purity
+  const now = Date.now()
+
+  const [admins, invitations] = await Promise.all([
+    prisma.adminUser.findMany({
+      where: { organizationId },
+      select: { id: true, email: true, name: true, role: true, isActive: true, createdAt: true },
+      orderBy: { createdAt: "asc" },
+    }),
+    prisma.adminInvitation.findMany({
+      where: { organizationId, acceptedAt: null, revokedAt: null, expiresAt: { gt: new Date() } },
+      orderBy: { createdAt: "desc" },
+      include: { inviter: { select: { name: true } } },
+    }),
+  ])
+
+  return (
+    <TeamManager
+      currentUserId={session.user.id ?? ""}
+      admins={admins.map((a) => ({
+        id: a.id,
+        email: a.email,
+        name: a.name,
+        role: a.role,
+        isActive: a.isActive,
+      }))}
+      invitations={invitations.map((i) => ({
+        id: i.id,
+        email: i.email,
+        daysLeft: daysUntil(i.expiresAt, now),
+        inviterName: i.inviter.name,
+      }))}
+    />
+  )
+}

--- a/src/app/api/admin/events/[id]/duplicate/route.ts
+++ b/src/app/api/admin/events/[id]/duplicate/route.ts
@@ -1,15 +1,15 @@
 import { NextResponse } from "next/server"
-import { auth } from "@/auth"
-import { prisma } from "@/lib/prisma"
+import { requireOrgSession } from "@/lib/auth-guard"
 import { slugify } from "@/lib/utils"
 
 export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db, organizationId } = guard
 
   const { id } = await params
 
-  const source = await prisma.event.findUnique({
+  const source = await db.event.findFirst({
     where: { id },
     include: { shifts: true },
   })
@@ -17,12 +17,13 @@ export async function POST(_req: Request, { params }: { params: Promise<{ id: st
   if (!source) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
   let slug = slugify(`${source.title}-copie`)
-  const existing = await prisma.event.findUnique({ where: { slug } })
+  const existing = await db.event.findFirst({ where: { slug } })
   if (existing) slug = `${slug}-${Date.now()}`
 
-  const newEvent = await prisma.event.create({
+  const newEvent = await db.event.create({
     data: {
       slug,
+      organizationId,
       title: `${source.title} (copie)`,
       description: source.description,
       location: source.location,

--- a/src/app/api/admin/events/[id]/export/pdf/route.ts
+++ b/src/app/api/admin/events/[id]/export/pdf/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server"
-import { auth } from "@/auth"
-import { prisma } from "@/lib/prisma"
+import { requireOrgSession } from "@/lib/auth-guard"
 
 type VolData = { firstName: string; lastName: string; email: string; phone: string | null }
 type RegData  = { volunteer: VolData; comment: string | null; source: string }
@@ -193,12 +192,13 @@ function buildDayHtml(date: Date, shifts: ShiftRow[], shows: ShowEntry[]): strin
 }
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const { id } = await params
 
-  const event = await prisma.event.findUnique({
+  const event = await db.event.findFirst({
     where: { id },
     include: {
       shifts: {

--- a/src/app/api/admin/events/[id]/export/route.ts
+++ b/src/app/api/admin/events/[id]/export/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server"
-import { auth } from "@/auth"
-import { prisma } from "@/lib/prisma"
+import { requireOrgSession } from "@/lib/auth-guard"
 import ExcelJS from "exceljs"
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -318,12 +317,13 @@ function buildDaySheet(wb: ExcelJS.Workbook, name: string, shifts: ShiftRow[], s
 // ── Main handler ─────────────────────────────────────────────────────────────
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const { id } = await params
 
-  const event = await prisma.event.findUnique({
+  const event = await db.event.findFirst({
     where: { id },
     include: {
       shifts: {

--- a/src/app/api/admin/events/[id]/invitations/remind/route.ts
+++ b/src/app/api/admin/events/[id]/invitations/remind/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import { sendMemberInvite } from "@/lib/email"
+import { z } from "zod"
+
+const schema = z.object({
+  message: z.string().max(500).optional(),
+})
+
+/**
+ * Re-sends the invitation email to every invited member who has not yet
+ * registered to the event. Reuses the existing token (no duplicate row).
+ */
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
+
+  const { id: eventId } = await params
+  const body = await req.json().catch(() => ({}))
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const event = await db.event.findFirst({
+    where: { id: eventId },
+    include: { organization: { select: { name: true } } },
+  })
+  if (!event) return NextResponse.json({ error: "Événement non trouvé" }, { status: 404 })
+
+  const invites = await db.memberInvite.findMany({
+    where: { eventId },
+    include: { member: true },
+  })
+
+  const memberEmails = invites
+    .map((i) => i.member.email)
+    .filter((e): e is string => !!e)
+
+  const registeredEmails = new Set(
+    memberEmails.length
+      ? (
+          await prisma.registration.findMany({
+            where: {
+              eventId,
+              status: "active",
+              volunteer: { email: { in: memberEmails } },
+            },
+            select: { volunteer: { select: { email: true } } },
+          })
+        ).map((r) => r.volunteer.email)
+      : [],
+  )
+
+  let sent = 0
+  let failed = 0
+  for (const invite of invites) {
+    const m = invite.member
+    if (!m.email || !m.active) continue
+    if (registeredEmails.has(m.email)) continue
+    try {
+      await sendMemberInvite({
+        to: m.email,
+        memberName: m.firstName,
+        organizationName: event.organization.name,
+        eventTitle: event.title,
+        eventDate: event.startDate.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" }),
+        eventLocation: event.location,
+        eventSlug: event.slug,
+        message: parsed.data.message ?? null,
+        token: invite.token,
+      })
+      sent++
+    } catch (err) {
+      console.error("Reminder email error:", err)
+      failed++
+    }
+  }
+
+  return NextResponse.json({ sent, failed })
+}

--- a/src/app/api/admin/events/[id]/invitations/route.ts
+++ b/src/app/api/admin/events/[id]/invitations/route.ts
@@ -125,31 +125,36 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     created.push(invite)
   }
 
-  // Send emails (only to members with an email and never invited yet).
-  let sent = 0
-  let failed = 0
-  for (const member of members) {
-    if (!member.email) continue
-    const invite = existingByMember.get(member.id) ?? created.find((c) => c.memberId === member.id)
-    if (!invite) continue
-    try {
-      await sendMemberInvite({
-        to: member.email,
-        memberName: member.firstName,
-        organizationName: event.organization.name,
-        eventTitle: event.title,
-        eventDate: event.startDate.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" }),
-        eventLocation: event.location,
-        eventSlug: event.slug,
-        message: parsed.data.message ?? null,
-        token: invite.token,
-      })
-      sent++
-    } catch (err) {
-      console.error("Member invite email error:", err)
-      failed++
-    }
-  }
+  // Send emails in parallel so a slow SMTP doesn't make the route
+  // hang for `members.length × timeout`. Promise.allSettled keeps a
+  // partial failure from cancelling the others.
+  const sends = members
+    .filter((m) => m.email)
+    .map(async (member) => {
+      const invite = existingByMember.get(member.id) ?? created.find((c) => c.memberId === member.id)
+      if (!invite) return { ok: false }
+      try {
+        await sendMemberInvite({
+          to: member.email!,
+          memberName: member.firstName,
+          organizationName: event.organization.name,
+          eventTitle: event.title,
+          eventDate: event.startDate.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" }),
+          eventLocation: event.location,
+          eventSlug: event.slug,
+          message: parsed.data.message ?? null,
+          token: invite.token,
+        })
+        return { ok: true }
+      } catch (err) {
+        console.error("Member invite email error:", err)
+        return { ok: false }
+      }
+    })
+
+  const results = await Promise.allSettled(sends)
+  const sent = results.filter((r) => r.status === "fulfilled" && r.value.ok).length
+  const failed = results.length - sent
 
   return NextResponse.json({
     invitedNew: created.length,

--- a/src/app/api/admin/events/[id]/invitations/route.ts
+++ b/src/app/api/admin/events/[id]/invitations/route.ts
@@ -1,0 +1,161 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import { sendMemberInvite } from "@/lib/email"
+import { z } from "zod"
+
+const postSchema = z.object({
+  memberIds: z.array(z.string()).min(1).max(500),
+  message: z.string().max(500).optional(),
+})
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
+
+  const { id: eventId } = await params
+
+  const event = await db.event.findFirst({ where: { id: eventId }, select: { id: true } })
+  if (!event) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+
+  const invites = await db.memberInvite.findMany({
+    where: { eventId },
+    include: {
+      member: {
+        select: { id: true, firstName: true, lastName: true, email: true, tags: true, active: true },
+      },
+    },
+    orderBy: { sentAt: "desc" },
+  })
+
+  // Pull the active registrations for the same members on this event so
+  // the UI can show "registered" vs "no answer".
+  const memberIds = invites.map((i) => i.memberId)
+  const memberEmails = invites
+    .map((i) => i.member.email)
+    .filter((e): e is string => !!e)
+
+  const registrationsByEmail = memberEmails.length
+    ? await prisma.registration.findMany({
+        where: {
+          eventId,
+          status: "active",
+          volunteer: { email: { in: memberEmails } },
+        },
+        include: {
+          volunteer: { select: { email: true } },
+          shift: { select: { id: true, label: true, roleName: true, startTime: true, endTime: true } },
+        },
+      })
+    : []
+
+  const regsByEmail = new Map<string, typeof registrationsByEmail>()
+  for (const r of registrationsByEmail) {
+    const key = r.volunteer.email
+    if (!regsByEmail.has(key)) regsByEmail.set(key, [])
+    regsByEmail.get(key)!.push(r)
+  }
+
+  const total = invites.length
+  const registered = invites.filter((i) => i.member.email && (regsByEmail.get(i.member.email)?.length ?? 0) > 0).length
+  const noAnswer = total - registered
+
+  return NextResponse.json({
+    summary: { total, registered, noAnswer },
+    invites: invites.map((i) => ({
+      id: i.id,
+      sentAt: i.sentAt,
+      usedAt: i.usedAt,
+      member: i.member,
+      registrations:
+        i.member.email
+          ? (regsByEmail.get(i.member.email) ?? []).map((r) => ({
+              shiftId: r.shift.id,
+              label: r.shift.label,
+              roleName: r.shift.roleName,
+              startTime: r.shift.startTime,
+              endTime: r.shift.endTime,
+            }))
+          : [],
+    })),
+    memberIds,
+  })
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
+
+  const { id: eventId } = await params
+  const body = await req.json()
+  const parsed = postSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const event = await db.event.findFirst({
+    where: { id: eventId },
+    include: { organization: { select: { name: true } } },
+  })
+  if (!event) return NextResponse.json({ error: "Événement non trouvé" }, { status: 404 })
+
+  // Only consider members that belong to this org.
+  const members = await db.member.findMany({
+    where: { id: { in: parsed.data.memberIds }, active: true },
+  })
+
+  if (members.length === 0) {
+    return NextResponse.json({ error: "Aucun membre valide à inviter" }, { status: 400 })
+  }
+
+  // Existing invites for this event so we don't recreate them.
+  const existing = await prisma.memberInvite.findMany({
+    where: { eventId, memberId: { in: members.map((m) => m.id) } },
+    select: { memberId: true, id: true, token: true },
+  })
+  const existingByMember = new Map(existing.map((e) => [e.memberId, e]))
+
+  const created: { id: string; memberId: string; token: string }[] = []
+  for (const member of members) {
+    if (existingByMember.has(member.id)) continue
+    const invite = await prisma.memberInvite.create({
+      data: { eventId, memberId: member.id },
+      select: { id: true, memberId: true, token: true },
+    })
+    created.push(invite)
+  }
+
+  // Send emails (only to members with an email and never invited yet).
+  let sent = 0
+  let failed = 0
+  for (const member of members) {
+    if (!member.email) continue
+    const invite = existingByMember.get(member.id) ?? created.find((c) => c.memberId === member.id)
+    if (!invite) continue
+    try {
+      await sendMemberInvite({
+        to: member.email,
+        memberName: member.firstName,
+        organizationName: event.organization.name,
+        eventTitle: event.title,
+        eventDate: event.startDate.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" }),
+        eventLocation: event.location,
+        eventSlug: event.slug,
+        message: parsed.data.message ?? null,
+        token: invite.token,
+      })
+      sent++
+    } catch (err) {
+      console.error("Member invite email error:", err)
+      failed++
+    }
+  }
+
+  return NextResponse.json({
+    invitedNew: created.length,
+    skippedExisting: members.length - created.length,
+    emailsSent: sent,
+    emailsFailed: failed,
+    membersWithoutEmail: members.filter((m) => !m.email).length,
+  }, { status: 201 })
+}

--- a/src/app/api/admin/events/[id]/qr/route.ts
+++ b/src/app/api/admin/events/[id]/qr/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { env } from "@/lib/env"
+import QRCode from "qrcode"
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
+
+  const { id } = await params
+  const url = new URL(req.url)
+  const format = (url.searchParams.get("format") ?? "png").toLowerCase()
+
+  const event = await db.event.findFirst({
+    where: { id },
+    select: { slug: true, title: true },
+  })
+  if (!event) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+
+  const baseUrl = env.NEXT_PUBLIC_APP_URL ?? new URL(req.url).origin
+  const target = `${baseUrl.replace(/\/$/, "")}/events/${event.slug}`
+
+  if (format === "svg") {
+    const svg = await QRCode.toString(target, { type: "svg", margin: 2, width: 600 })
+    return new NextResponse(svg, {
+      headers: {
+        "Content-Type": "image/svg+xml",
+        "Content-Disposition": `inline; filename="${event.slug}-qr.svg"`,
+      },
+    })
+  }
+
+  const buffer = await QRCode.toBuffer(target, { type: "png", margin: 2, width: 600 })
+  return new NextResponse(new Uint8Array(buffer), {
+    headers: {
+      "Content-Type": "image/png",
+      "Content-Disposition": `inline; filename="${event.slug}-qr.png"`,
+    },
+  })
+}

--- a/src/app/api/admin/events/[id]/reorder-roles/route.ts
+++ b/src/app/api/admin/events/[id]/reorder-roles/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server"
-import { auth } from "@/auth"
+import { requireOrgSession } from "@/lib/auth-guard"
 import { prisma } from "@/lib/prisma"
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db, organizationId } = guard
 
   const { id } = await params
   const { roleOrder } = await req.json()
@@ -13,10 +14,13 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     return NextResponse.json({ error: "roleOrder doit être un tableau" }, { status: 400 })
   }
 
+  const owned = await db.event.findFirst({ where: { id }, select: { id: true } })
+  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+
   await Promise.all(
     (roleOrder as string[]).map((roleName, index) =>
       prisma.shift.updateMany({
-        where: { eventId: id, roleName },
+        where: { eventId: id, roleName, event: { organizationId } },
         data: { displayOrder: index * 100 },
       })
     )

--- a/src/app/api/admin/events/[id]/route.ts
+++ b/src/app/api/admin/events/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { auth } from "@/auth"
+import { requireOrgSession } from "@/lib/auth-guard"
 import { prisma } from "@/lib/prisma"
 import { z } from "zod"
 
@@ -23,12 +23,13 @@ const schema = z.object({
 })
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const { id } = await params
 
-  const event = await prisma.event.findUnique({
+  const event = await db.event.findFirst({
     where: { id },
     include: {
       shifts: {
@@ -44,13 +45,17 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
 }
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const { id } = await params
   const body = await req.json()
   const parsed = schema.safeParse(body)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const owned = await db.event.findFirst({ where: { id }, select: { id: true } })
+  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
   const data = parsed.data
   const updateData: Record<string, unknown> = { ...data }
@@ -67,10 +72,14 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 }
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const { id } = await params
+
+  const owned = await db.event.findFirst({ where: { id }, select: { id: true } })
+  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
   await prisma.event.update({ where: { id }, data: { publicStatus: "archived" } })
   return NextResponse.json({ success: true })

--- a/src/app/api/admin/events/[id]/route.ts
+++ b/src/app/api/admin/events/[id]/route.ts
@@ -20,6 +20,8 @@ const schema = z.object({
   confirmationMessage: z.string().optional().nullable(),
   publicStatus: z.enum(["draft", "published", "archived"]).optional(),
   showSchedule: z.array(showSchema).optional(),
+  reminderMessage: z.string().max(2000).optional().nullable(),
+  remindersEnabled: z.boolean().optional(),
 })
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {

--- a/src/app/api/admin/events/[id]/send-reminder/route.ts
+++ b/src/app/api/admin/events/[id]/send-reminder/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import { sendNotification } from "@/lib/notifications"
+
+/**
+ * POST /api/admin/events/[id]/send-reminder
+ *
+ * Sends one email per volunteer who has at least one active registration
+ * on the event. Each email contains the admin's custom reminder message
+ * (Event.reminderMessage) followed by the volunteer's own shifts.
+ */
+export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
+
+  const { id } = await params
+
+  const event = await db.event.findFirst({
+    where: { id },
+    include: { organization: { select: { name: true } } },
+  })
+  if (!event) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+
+  // Defense in depth: re-scope the registration lookup explicitly via
+  // event.organizationId so a route bug can't leak another org's data.
+  const regs = await prisma.registration.findMany({
+    where: {
+      eventId: id,
+      status: "active",
+      event: { organizationId: event.organizationId },
+    },
+    include: { volunteer: true, shift: true },
+    orderBy: [{ shift: { date: "asc" } }, { shift: { startTime: "asc" } }],
+  })
+
+  if (regs.length === 0) {
+    return NextResponse.json({ error: "Aucun bénévole inscrit" }, { status: 400 })
+  }
+
+  // Group registrations by volunteer (one email per person, even if
+  // they have several shifts). Use the volunteer.id as key so we don't
+  // depend on a single editToken per volunteer.
+  type Bundle = {
+    volunteer: typeof regs[number]["volunteer"]
+    editToken: string
+    shifts: typeof regs[number]["shift"][]
+  }
+  const byVolunteer = new Map<string, Bundle>()
+  for (const r of regs) {
+    let bundle = byVolunteer.get(r.volunteerId)
+    if (!bundle) {
+      bundle = { volunteer: r.volunteer, editToken: r.editToken, shifts: [] }
+      byVolunteer.set(r.volunteerId, bundle)
+    }
+    bundle.shifts.push(r.shift)
+  }
+
+  let sent = 0
+  let failed = 0
+  for (const bundle of byVolunteer.values()) {
+    if (!bundle.volunteer.email) continue
+    const result = await sendNotification({
+      kind: "manual_reminder",
+      recipient: { email: bundle.volunteer.email, name: bundle.volunteer.firstName },
+      data: {
+        volunteerName: bundle.volunteer.firstName,
+        organizationName: event.organization.name,
+        eventTitle: event.title,
+        customMessage: event.reminderMessage ?? "",
+        shifts: bundle.shifts.map((s) => ({
+          label: s.label,
+          date: s.date.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" }),
+          startTime: s.startTime,
+          endTime: s.endTime,
+          roleName: s.roleName,
+        })),
+        editToken: bundle.editToken,
+      },
+    })
+    if (result.ok) sent++
+    else failed++
+  }
+
+  await prisma.event.update({
+    where: { id },
+    data: { reminderSentAt: new Date() },
+  })
+
+  return NextResponse.json({ sent, failed, totalVolunteers: byVolunteer.size })
+}

--- a/src/app/api/admin/events/route.ts
+++ b/src/app/api/admin/events/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server"
-import { auth } from "@/auth"
-import { prisma } from "@/lib/prisma"
+import { requireOrgSession } from "@/lib/auth-guard"
 import { slugify } from "@/lib/utils"
 import { z } from "zod"
 
@@ -16,10 +15,11 @@ const schema = z.object({
 })
 
 export async function GET() {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
-  const events = await prisma.event.findMany({
+  const events = await db.event.findMany({
     include: {
       shifts: {
         include: { registrations: { where: { status: "active" } } },
@@ -50,8 +50,9 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db, organizationId } = guard
 
   const body = await req.json()
   const parsed = schema.safeParse(body)
@@ -60,13 +61,14 @@ export async function POST(req: Request) {
   const data = parsed.data
   let slug = slugify(data.title)
 
-  const existing = await prisma.event.findUnique({ where: { slug } })
+  const existing = await db.event.findFirst({ where: { slug } })
   if (existing) slug = `${slug}-${Date.now()}`
 
-  const event = await prisma.event.create({
+  const event = await db.event.create({
     data: {
       ...data,
       slug,
+      organizationId,
       startDate: new Date(data.startDate),
       endDate: new Date(data.endDate),
       publicStatus: data.publicStatus ?? "draft",

--- a/src/app/api/admin/invitations/[id]/route.ts
+++ b/src/app/api/admin/invitations/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { organizationId } = guard
+
+  const { id } = await params
+
+  const invitation = await prisma.adminInvitation.findFirst({
+    where: { id, organizationId },
+  })
+  if (!invitation) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+
+  await prisma.adminInvitation.update({
+    where: { id },
+    data: { revokedAt: new Date() },
+  })
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/invitations/route.ts
+++ b/src/app/api/admin/invitations/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import { sendNotification } from "@/lib/notifications"
+import { z } from "zod"
+
+const createSchema = z.object({
+  email: z.string().email(),
+})
+
+const INVITATION_TTL_DAYS = 7
+
+export async function GET() {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { organizationId } = guard
+
+  const invitations = await prisma.adminInvitation.findMany({
+    where: { organizationId },
+    orderBy: { createdAt: "desc" },
+    include: { inviter: { select: { name: true, email: true } } },
+  })
+
+  return NextResponse.json(
+    invitations.map((i) => ({
+      id: i.id,
+      email: i.email,
+      role: i.role,
+      createdAt: i.createdAt,
+      expiresAt: i.expiresAt,
+      acceptedAt: i.acceptedAt,
+      revokedAt: i.revokedAt,
+      inviterName: i.inviter.name,
+    })),
+  )
+}
+
+export async function POST(req: Request) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { session, organizationId } = guard
+
+  const body = await req.json()
+  const parsed = createSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  // Refuse to invite an email that already has an admin account in this org.
+  const existingAdmin = await prisma.adminUser.findFirst({
+    where: { email: parsed.data.email, organizationId },
+  })
+  if (existingAdmin) {
+    return NextResponse.json({ error: "Cet email est déjà admin de l'organisation" }, { status: 409 })
+  }
+
+  // Re-use a non-revoked, non-accepted invitation if it exists, refresh the
+  // expiry. Otherwise create a fresh one.
+  const expiresAt = new Date(Date.now() + INVITATION_TTL_DAYS * 24 * 3600 * 1000)
+  const existing = await prisma.adminInvitation.findUnique({
+    where: { email_organizationId: { email: parsed.data.email, organizationId } },
+  })
+
+  let invitation
+  if (existing && !existing.acceptedAt && !existing.revokedAt) {
+    invitation = await prisma.adminInvitation.update({
+      where: { id: existing.id },
+      data: { expiresAt, invitedBy: session.user.id! },
+    })
+  } else if (existing) {
+    // Reactivate a previously revoked / accepted one (rare but possible).
+    invitation = await prisma.adminInvitation.update({
+      where: { id: existing.id },
+      data: { expiresAt, revokedAt: null, acceptedAt: null, invitedBy: session.user.id! },
+    })
+  } else {
+    invitation = await prisma.adminInvitation.create({
+      data: {
+        email: parsed.data.email,
+        organizationId,
+        invitedBy: session.user.id!,
+        expiresAt,
+      },
+    })
+  }
+
+  // Look up the org name for the email template (small extra query, fine).
+  const org = await prisma.organization.findUnique({
+    where: { id: organizationId },
+    select: { name: true },
+  })
+
+  await sendNotification({
+    kind: "admin_invitation",
+    recipient: { email: parsed.data.email },
+    data: {
+      organizationName: org?.name ?? "votre organisation",
+      inviterName: session.user.name ?? "Un administrateur",
+      token: invitation.token,
+      expiresAt,
+    },
+  })
+
+  return NextResponse.json(
+    { id: invitation.id, email: invitation.email, expiresAt: invitation.expiresAt },
+    { status: 201 },
+  )
+}

--- a/src/app/api/admin/members/[id]/route.ts
+++ b/src/app/api/admin/members/[id]/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import { z } from "zod"
+
+const patchSchema = z.object({
+  firstName: z.string().min(1).optional(),
+  lastName: z.string().min(1).optional(),
+  email: z.string().email().optional().nullable().or(z.literal("")),
+  phone: z.string().optional().nullable(),
+  tags: z.array(z.string()).optional(),
+  notes: z.string().optional().nullable(),
+  active: z.boolean().optional(),
+})
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
+
+  const { id } = await params
+  const body = await req.json()
+  const parsed = patchSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const owned = await db.member.findFirst({ where: { id }, select: { id: true } })
+  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+
+  const data = parsed.data
+  const updateData: Record<string, unknown> = {}
+  if (data.firstName !== undefined) updateData.firstName = data.firstName
+  if (data.lastName !== undefined) updateData.lastName = data.lastName
+  if (data.email !== undefined) updateData.email = data.email || null
+  if (data.phone !== undefined) updateData.phone = data.phone || null
+  if (data.tags !== undefined) updateData.tags = data.tags
+  if (data.notes !== undefined) updateData.notes = data.notes || null
+  if (data.active !== undefined) updateData.active = data.active
+
+  const member = await prisma.member.update({ where: { id }, data: updateData })
+  return NextResponse.json(member)
+}
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
+
+  const { id } = await params
+
+  const owned = await db.member.findFirst({ where: { id }, select: { id: true } })
+  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+
+  // Soft delete: keep history (invites, future stats) but hide from rosters.
+  await prisma.member.update({ where: { id }, data: { active: false } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/members/import/route.ts
+++ b/src/app/api/admin/members/import/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import { parseCsv, parseXlsx } from "@/lib/csv-import"
+
+export async function POST(req: Request) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { organizationId } = guard
+
+  const form = await req.formData()
+  const file = form.get("file")
+  const onDuplicate = (form.get("onDuplicate") as string) ?? "skip" // "skip" | "update"
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Fichier manquant" }, { status: 400 })
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer())
+  const isXlsx =
+    file.name.toLowerCase().endsWith(".xlsx") ||
+    file.type === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+  let preview
+  try {
+    preview = isXlsx ? await parseXlsx(buffer) : parseCsv(buffer)
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Impossible de lire le fichier", detail: String(err) },
+      { status: 400 },
+    )
+  }
+
+  if (preview.rows.length === 0 && preview.errors.length === 0) {
+    return NextResponse.json({ error: "Le fichier est vide" }, { status: 400 })
+  }
+
+  let created = 0
+  let updated = 0
+  let skipped = 0
+  const errors = [...preview.errors]
+
+  // Pre-fetch existing emails to avoid one query per row.
+  const emailsInImport = preview.rows.map((r) => r.email).filter((e): e is string => !!e)
+  const existing = emailsInImport.length
+    ? await prisma.member.findMany({
+        where: { organizationId, email: { in: emailsInImport } },
+        select: { id: true, email: true },
+      })
+    : []
+  const existingByEmail = new Map(existing.map((m) => [m.email, m.id]))
+
+  for (const row of preview.rows) {
+    const existingId = row.email ? existingByEmail.get(row.email) : undefined
+    if (existingId) {
+      if (onDuplicate === "update") {
+        await prisma.member.update({
+          where: { id: existingId },
+          data: {
+            firstName: row.firstName,
+            lastName: row.lastName,
+            phone: row.phone ?? null,
+            tags: row.tags ?? [],
+            active: true,
+          },
+        })
+        updated++
+      } else {
+        skipped++
+      }
+    } else {
+      try {
+        await prisma.member.create({
+          data: {
+            organizationId,
+            firstName: row.firstName,
+            lastName: row.lastName,
+            email: row.email ?? null,
+            phone: row.phone ?? null,
+            tags: row.tags ?? [],
+          },
+        })
+        created++
+      } catch (err) {
+        errors.push({ line: -1, reason: `Échec création ${row.firstName} ${row.lastName} : ${String(err).slice(0, 100)}` })
+      }
+    }
+  }
+
+  return NextResponse.json({
+    created,
+    updated,
+    skipped,
+    errors,
+    detectedColumns: preview.detectedColumns,
+    totalParsed: preview.rows.length,
+  })
+}

--- a/src/app/api/admin/members/route.ts
+++ b/src/app/api/admin/members/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { z } from "zod"
+
+const memberSchema = z.object({
+  firstName: z.string().min(1).max(100),
+  lastName: z.string().min(1).max(100),
+  email: z.string().email().optional().or(z.literal("")),
+  phone: z.string().max(50).optional(),
+  tags: z.array(z.string()).optional(),
+  notes: z.string().optional(),
+  active: z.boolean().optional(),
+})
+
+export async function GET(req: Request) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
+
+  const url = new URL(req.url)
+  const search = url.searchParams.get("q")?.trim() ?? ""
+  const tag = url.searchParams.get("tag")?.trim() ?? ""
+
+  const members = await db.member.findMany({
+    where: {
+      ...(search
+        ? {
+            OR: [
+              { firstName: { contains: search, mode: "insensitive" } },
+              { lastName: { contains: search, mode: "insensitive" } },
+              { email: { contains: search, mode: "insensitive" } },
+            ],
+          }
+        : {}),
+      ...(tag ? { tags: { has: tag } } : {}),
+    },
+    orderBy: [{ active: "desc" }, { lastName: "asc" }, { firstName: "asc" }],
+  })
+
+  return NextResponse.json(members)
+}
+
+export async function POST(req: Request) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db, organizationId } = guard
+
+  const body = await req.json()
+  const parsed = memberSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+  const data = parsed.data
+
+  if (data.email) {
+    const existing = await db.member.findFirst({ where: { email: data.email } })
+    if (existing) {
+      return NextResponse.json(
+        { error: "Un membre avec cet email existe déjà." },
+        { status: 409 },
+      )
+    }
+  }
+
+  const member = await db.member.create({
+    data: {
+      organizationId,
+      firstName: data.firstName,
+      lastName: data.lastName,
+      email: data.email || null,
+      phone: data.phone || null,
+      tags: data.tags ?? [],
+      notes: data.notes || null,
+      active: data.active ?? true,
+    },
+  })
+
+  return NextResponse.json(member, { status: 201 })
+}

--- a/src/app/api/admin/registrations/[id]/route.ts
+++ b/src/app/api/admin/registrations/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { auth } from "@/auth"
+import { requireOrgSession } from "@/lib/auth-guard"
 import { prisma } from "@/lib/prisma"
 import { z } from "zod"
 
@@ -9,13 +9,17 @@ const schema = z.object({
 })
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const { id } = await params
   const body = await req.json()
   const parsed = schema.safeParse(body)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const owned = await db.registration.findFirst({ where: { id }, select: { id: true } })
+  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
   const registration = await prisma.registration.update({
     where: { id },
@@ -40,10 +44,14 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 }
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const { id } = await params
+
+  const owned = await db.registration.findFirst({ where: { id }, select: { id: true } })
+  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
   const registration = await prisma.registration.update({
     where: { id },

--- a/src/app/api/admin/registrations/route.ts
+++ b/src/app/api/admin/registrations/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { auth } from "@/auth"
+import { requireOrgSession } from "@/lib/auth-guard"
 import { prisma } from "@/lib/prisma"
 import { generateToken } from "@/lib/utils"
 import { z } from "zod"
@@ -15,8 +15,9 @@ const schema = z.object({
 })
 
 export async function POST(req: Request) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const body = await req.json()
   const parsed = schema.safeParse(body)
@@ -24,7 +25,7 @@ export async function POST(req: Request) {
 
   const { eventId, shiftId, firstName, lastName, email, phone, comment } = parsed.data
 
-  const shift = await prisma.shift.findFirst({
+  const shift = await db.shift.findFirst({
     where: { id: shiftId, eventId },
     include: { registrations: { where: { status: "active" } } },
   })

--- a/src/app/api/admin/shifts/[id]/route.ts
+++ b/src/app/api/admin/shifts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { requireOrgSession } from "@/lib/auth-guard"
 import { prisma } from "@/lib/prisma"
+import { sendNotification } from "@/lib/notifications"
 import { z } from "zod"
 
 const schema = z.object({
@@ -15,7 +16,13 @@ const schema = z.object({
   locationDetails: z.string().optional().nullable(),
   displayOrder: z.number().int().optional(),
   internalNotes: z.string().optional().nullable(),
+  // Caller can opt out of notifying volunteers (default true).
+  notifyVolunteers: z.boolean().optional(),
 })
+
+function fmtDate(d: Date) {
+  return d.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" })
+}
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const guard = await requireOrgSession()
@@ -27,15 +34,54 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   const parsed = schema.safeParse(body)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
 
-  const owned = await db.shift.findFirst({ where: { id }, select: { id: true } })
-  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+  const before = await db.shift.findFirst({
+    where: { id },
+    include: {
+      event: { select: { id: true, title: true, slug: true, organizationId: true } },
+      registrations: {
+        where: { status: "active" },
+        include: { volunteer: true },
+      },
+    },
+  })
+  if (!before) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
-  const data = parsed.data
-  const updateData: Record<string, unknown> = { ...data }
-  if (data.date) updateData.date = new Date(data.date)
+  const { notifyVolunteers, ...rest } = parsed.data
+  const updateData: Record<string, unknown> = { ...rest }
+  if (rest.date) updateData.date = new Date(rest.date)
 
-  const shift = await prisma.shift.update({ where: { id }, data: updateData })
-  return NextResponse.json(shift)
+  const after = await prisma.shift.update({ where: { id }, data: updateData })
+
+  // Detect schedule changes worth notifying about (date / start / end).
+  const scheduleChanged =
+    (rest.date && before.date.toISOString() !== after.date.toISOString()) ||
+    (rest.startTime && before.startTime !== after.startTime) ||
+    (rest.endTime && before.endTime !== after.endTime)
+
+  let notified = 0
+  if (scheduleChanged && notifyVolunteers !== false && before.registrations.length > 0) {
+    for (const reg of before.registrations) {
+      const result = await sendNotification({
+        kind: "shift_modified",
+        recipient: { email: reg.volunteer.email, name: reg.volunteer.firstName },
+        data: {
+          volunteerName: reg.volunteer.firstName,
+          eventTitle: before.event.title,
+          shiftLabel: after.label,
+          oldDate: fmtDate(before.date),
+          newDate: fmtDate(after.date),
+          oldStart: before.startTime,
+          newStart: after.startTime,
+          oldEnd: before.endTime,
+          newEnd: after.endTime,
+          editToken: reg.editToken,
+        },
+      })
+      if (result.ok) notified++
+    }
+  }
+
+  return NextResponse.json({ ...after, notified })
 }
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -45,9 +91,37 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
 
   const { id } = await params
 
-  const owned = await db.shift.findFirst({ where: { id }, select: { id: true } })
-  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+  const shift = await db.shift.findFirst({
+    where: { id },
+    include: {
+      event: { select: { title: true, slug: true } },
+      registrations: { where: { status: "active" }, include: { volunteer: true } },
+    },
+  })
+  if (!shift) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
   await prisma.shift.update({ where: { id }, data: { status: "cancelled" } })
-  return NextResponse.json({ success: true })
+
+  // Cascade-cancel active registrations and notify each volunteer.
+  let notified = 0
+  for (const reg of shift.registrations) {
+    await prisma.registration.update({
+      where: { id: reg.id },
+      data: { status: "cancelled" },
+    })
+    const result = await sendNotification({
+      kind: "shift_cancelled",
+      recipient: { email: reg.volunteer.email, name: reg.volunteer.firstName },
+      data: {
+        volunteerName: reg.volunteer.firstName,
+        eventTitle: shift.event.title,
+        eventSlug: shift.event.slug,
+        shiftLabel: shift.label,
+        shiftDate: fmtDate(shift.date),
+      },
+    })
+    if (result.ok) notified++
+  }
+
+  return NextResponse.json({ success: true, cancelledRegistrations: shift.registrations.length, notified })
 }

--- a/src/app/api/admin/shifts/[id]/route.ts
+++ b/src/app/api/admin/shifts/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { auth } from "@/auth"
+import { requireOrgSession } from "@/lib/auth-guard"
 import { prisma } from "@/lib/prisma"
 import { z } from "zod"
 
@@ -18,13 +18,17 @@ const schema = z.object({
 })
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const { id } = await params
   const body = await req.json()
   const parsed = schema.safeParse(body)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const owned = await db.shift.findFirst({ where: { id }, select: { id: true } })
+  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
   const data = parsed.data
   const updateData: Record<string, unknown> = { ...data }
@@ -35,10 +39,14 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 }
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const { id } = await params
+
+  const owned = await db.shift.findFirst({ where: { id }, select: { id: true } })
+  if (!owned) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
 
   await prisma.shift.update({ where: { id }, data: { status: "cancelled" } })
   return NextResponse.json({ success: true })

--- a/src/app/api/admin/shifts/route.ts
+++ b/src/app/api/admin/shifts/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { auth } from "@/auth"
+import { requireOrgSession } from "@/lib/auth-guard"
 import { prisma } from "@/lib/prisma"
 import { z } from "zod"
 
@@ -18,14 +18,19 @@ const schema = z.object({
 })
 
 export async function POST(req: Request) {
-  const session = await auth()
-  if (!session) return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { db } = guard
 
   const body = await req.json()
   const parsed = schema.safeParse(body)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
 
   const data = parsed.data
+
+  const owned = await db.event.findFirst({ where: { id: data.eventId }, select: { id: true } })
+  if (!owned) return NextResponse.json({ error: "Événement introuvable" }, { status: 404 })
+
   const shift = await prisma.shift.create({
     data: { ...data, date: new Date(data.date), status: "open" },
   })

--- a/src/app/api/admin/team/[id]/route.ts
+++ b/src/app/api/admin/team/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+
+/**
+ * DELETE — deactivate an admin in the caller's organization.
+ * Refuses if the target is the caller themselves or the last active
+ * admin of the org (to avoid locking everyone out).
+ */
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { session, organizationId } = guard
+
+  const { id } = await params
+
+  if (id === session.user.id) {
+    return NextResponse.json({ error: "Tu ne peux pas te désactiver toi-même" }, { status: 400 })
+  }
+
+  const target = await prisma.adminUser.findFirst({
+    where: { id, organizationId },
+  })
+  if (!target) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+
+  const remainingActive = await prisma.adminUser.count({
+    where: { organizationId, isActive: true, id: { not: id } },
+  })
+  if (remainingActive === 0) {
+    return NextResponse.json(
+      { error: "Impossible de désactiver le dernier admin de l'organisation" },
+      { status: 400 },
+    )
+  }
+
+  await prisma.adminUser.update({ where: { id }, data: { isActive: false } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/team/route.ts
+++ b/src/app/api/admin/team/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server"
+import { requireOrgSession } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+
+/**
+ * GET — list of admins of the caller's organization. Used by the
+ * /admin/settings/members page to render the team table.
+ */
+export async function GET() {
+  const guard = await requireOrgSession()
+  if (guard instanceof NextResponse) return guard
+  const { organizationId } = guard
+
+  const admins = await prisma.adminUser.findMany({
+    where: { organizationId },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      role: true,
+      isActive: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "asc" },
+  })
+
+  return NextResponse.json(admins)
+}

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { sendNotification } from "@/lib/notifications"
+import type { NotificationKind } from "@/lib/notifications"
+
+export const dynamic = "force-dynamic"
+
+// Auth: any caller must present `Authorization: Bearer <CRON_SECRET>`.
+// In dev, if CRON_SECRET is unset we allow localhost requests so a manual
+// `curl http://localhost:3000/api/cron/reminders` works for testing.
+function isAuthorized(req: Request): boolean {
+  const expected = process.env.CRON_SECRET
+  const auth = req.headers.get("authorization")
+  if (expected) {
+    return auth === `Bearer ${expected}`
+  }
+  // No secret configured → only allow on localhost (dev mode).
+  const host = req.headers.get("host") ?? ""
+  return host.startsWith("localhost") || host.startsWith("127.0.0.1")
+}
+
+type Window = { kind: NotificationKind; field: "reminderJ2Sent" | "reminderJ1Sent" | "reminderDdSent"; minHours: number; maxHours: number }
+
+const WINDOWS: Window[] = [
+  { kind: "reminder_j2", field: "reminderJ2Sent", minHours: 47, maxHours: 49 },
+  { kind: "reminder_j1", field: "reminderJ1Sent", minHours: 23, maxHours: 25 },
+  { kind: "reminder_dd", field: "reminderDdSent", minHours: 2,  maxHours: 4 },
+]
+
+/**
+ * Combines a Shift.date (calendar day) with its startTime ("HH:MM") into
+ * a real timestamp. Stored times are local strings; we treat them as UTC
+ * which is fine for relative windows.
+ */
+function shiftStartAt(date: Date, startTime: string): Date {
+  const [h, m] = startTime.split(":").map(Number)
+  const d = new Date(date)
+  d.setUTCHours(h ?? 0, m ?? 0, 0, 0)
+  return d
+}
+
+export async function GET(req: Request) {
+  return run(req)
+}
+
+export async function POST(req: Request) {
+  return run(req)
+}
+
+async function run(req: Request) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const now = new Date()
+  const totals: Record<string, { eligible: number; sent: number; failed: number }> = {}
+
+  for (const win of WINDOWS) {
+    const lower = new Date(now.getTime() + win.minHours * 3600 * 1000)
+    const upper = new Date(now.getTime() + win.maxHours * 3600 * 1000)
+
+    // Pull every active registration that has not received this reminder
+    // yet AND whose shift starts inside the [lower, upper] window. The
+    // window is computed on the candidate set in JS (cheap with index +
+    // status filter).
+    const candidates = await prisma.registration.findMany({
+      where: {
+        status: "active",
+        [win.field]: null,
+        event: { remindersEnabled: true, publicStatus: "published" },
+        shift: { status: { not: "cancelled" } },
+      },
+      include: {
+        volunteer: true,
+        shift: true,
+        event: { include: { organization: { select: { name: true } } } },
+      },
+    })
+
+    const inWindow = candidates.filter((r) => {
+      const start = shiftStartAt(r.shift.date, r.shift.startTime)
+      return start >= lower && start <= upper
+    })
+
+    let sent = 0
+    let failed = 0
+    for (const r of inWindow) {
+      const start = shiftStartAt(r.shift.date, r.shift.startTime)
+      const result = await sendNotification({
+        kind: win.kind,
+        recipient: { email: r.volunteer.email, name: r.volunteer.firstName },
+        data: {
+          volunteerName: r.volunteer.firstName,
+          eventTitle: r.event.title,
+          organizationName: r.event.organization.name,
+          shiftLabel: r.shift.label,
+          shiftRoleName: r.shift.roleName,
+          shiftDate: r.shift.date.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" }),
+          shiftStart: r.shift.startTime,
+          shiftEnd: r.shift.endTime,
+          shiftLocation: r.shift.locationDetails,
+          editToken: r.editToken,
+          hoursUntil: Math.max(0, Math.round((start.getTime() - now.getTime()) / (3600 * 1000))),
+        },
+      })
+      if (result.ok) {
+        await prisma.registration.update({
+          where: { id: r.id },
+          data: { [win.field]: now },
+        })
+        sent++
+      } else {
+        failed++
+      }
+    }
+
+    totals[win.kind] = { eligible: inWindow.length, sent, failed }
+  }
+
+  return NextResponse.json({
+    runAt: now.toISOString(),
+    totals,
+  })
+}

--- a/src/app/api/public/forgot-password/route.ts
+++ b/src/app/api/public/forgot-password/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { sendNotification } from "@/lib/notifications"
+import { z } from "zod"
+
+const schema = z.object({
+  email: z.string().email(),
+})
+
+const RESET_TTL_HOURS = 1
+
+/**
+ * POST /api/public/forgot-password
+ *
+ * Anti-enumeration: always returns 200 regardless of whether the email
+ * exists. The email is sent only if it does, but the caller never knows
+ * either way (avoids leaking which addresses are admins).
+ */
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}))
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) {
+    // Bad input → still return 200 to keep the anti-enumeration guarantee.
+    return NextResponse.json({ ok: true })
+  }
+
+  const user = await prisma.adminUser.findUnique({
+    where: { email: parsed.data.email },
+  })
+
+  if (user && user.isActive) {
+    const expiresAt = new Date(Date.now() + RESET_TTL_HOURS * 3600 * 1000)
+    const created = await prisma.passwordResetToken.create({
+      data: { userId: user.id, expiresAt },
+    })
+
+    await sendNotification({
+      kind: "password_reset",
+      recipient: { email: user.email, name: user.name },
+      data: {
+        userName: user.name,
+        token: created.token,
+        expiresAt,
+      },
+    })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/public/invitations/[token]/route.ts
+++ b/src/app/api/public/invitations/[token]/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import bcrypt from "bcryptjs"
+import { z } from "zod"
+
+const acceptSchema = z.object({
+  name: z.string().min(1).max(120),
+  password: z.string().min(8, "Le mot de passe doit faire au moins 8 caractères").max(200),
+})
+
+/**
+ * GET — preview the invitation (used by the acceptance page to show
+ * the org name and validate the token before showing the form).
+ */
+export async function GET(_req: Request, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params
+
+  const invitation = await prisma.adminInvitation.findUnique({
+    where: { token },
+    include: { organization: { select: { name: true, isActive: true } } },
+  })
+
+  if (!invitation) return NextResponse.json({ error: "Lien invalide" }, { status: 404 })
+  if (invitation.acceptedAt) return NextResponse.json({ error: "Invitation déjà acceptée" }, { status: 410 })
+  if (invitation.revokedAt) return NextResponse.json({ error: "Invitation révoquée" }, { status: 410 })
+  if (invitation.expiresAt < new Date()) return NextResponse.json({ error: "Invitation expirée" }, { status: 410 })
+  if (!invitation.organization.isActive) return NextResponse.json({ error: "Organisation désactivée" }, { status: 410 })
+
+  return NextResponse.json({
+    email: invitation.email,
+    organizationName: invitation.organization.name,
+  })
+}
+
+/**
+ * POST — accept: creates the AdminUser, marks the invitation as
+ * accepted. The acceptance page redirects to /admin/login afterwards.
+ */
+export async function POST(req: Request, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params
+  const body = await req.json()
+  const parsed = acceptSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const invitation = await prisma.adminInvitation.findUnique({
+    where: { token },
+    include: { organization: { select: { isActive: true } } },
+  })
+
+  if (!invitation) return NextResponse.json({ error: "Lien invalide" }, { status: 404 })
+  if (invitation.acceptedAt) return NextResponse.json({ error: "Invitation déjà acceptée" }, { status: 410 })
+  if (invitation.revokedAt) return NextResponse.json({ error: "Invitation révoquée" }, { status: 410 })
+  if (invitation.expiresAt < new Date()) return NextResponse.json({ error: "Invitation expirée" }, { status: 410 })
+  if (!invitation.organization.isActive) return NextResponse.json({ error: "Organisation désactivée" }, { status: 410 })
+
+  // Reject if an account with this email already exists (we don't want
+  // to silently merge a super_admin or another org's admin).
+  const existing = await prisma.adminUser.findUnique({ where: { email: invitation.email } })
+  if (existing) {
+    return NextResponse.json(
+      { error: "Un compte existe déjà avec cet email. Connecte-toi puis demande à un super admin de t'attribuer l'organisation." },
+      { status: 409 },
+    )
+  }
+
+  const passwordHash = await bcrypt.hash(parsed.data.password, 12)
+
+  await prisma.$transaction([
+    prisma.adminUser.create({
+      data: {
+        email: invitation.email,
+        name: parsed.data.name,
+        passwordHash,
+        role: invitation.role,
+        organizationId: invitation.organizationId,
+      },
+    }),
+    prisma.adminInvitation.update({
+      where: { id: invitation.id },
+      data: { acceptedAt: new Date() },
+    }),
+  ])
+
+  return NextResponse.json({ success: true, email: invitation.email })
+}

--- a/src/app/api/public/member-invite/[token]/route.ts
+++ b/src/app/api/public/member-invite/[token]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+
+/**
+ * Public endpoint that resolves a MemberInvite token to the member info
+ * needed to pre-fill the registration form. Validates that the invite
+ * belongs to the same event as the requested slug.
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params
+  const url = new URL(req.url)
+  const expectedSlug = url.searchParams.get("slug")
+
+  const invite = await prisma.memberInvite.findUnique({
+    where: { token },
+    include: {
+      member: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+          phone: true,
+          active: true,
+        },
+      },
+      event: { select: { slug: true, organizationId: true } },
+    },
+  })
+
+  if (!invite || !invite.member.active) {
+    return NextResponse.json({ error: "Lien invalide" }, { status: 404 })
+  }
+
+  // Defense: refuse to leak member info if the token does not match the
+  // event the visitor is currently looking at.
+  if (expectedSlug && invite.event.slug !== expectedSlug) {
+    return NextResponse.json({ error: "Lien invalide" }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    eventSlug: invite.event.slug,
+    member: {
+      firstName: invite.member.firstName,
+      lastName: invite.member.lastName,
+      email: invite.member.email ?? "",
+      phone: invite.member.phone ?? "",
+    },
+  })
+}

--- a/src/app/api/public/registrations/route.ts
+++ b/src/app/api/public/registrations/route.ts
@@ -13,6 +13,7 @@ const schema = z.object({
   phone: z.string().optional(),
   comment: z.string().optional(),
   consent: z.literal(true),
+  inviteToken: z.string().optional(),
 })
 
 export async function POST(req: Request) {
@@ -22,7 +23,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Données invalides", details: parsed.error.flatten() }, { status: 400 })
   }
 
-  const { eventId, shiftIds, firstName, lastName, email, phone, comment } = parsed.data
+  const { eventId, shiftIds, firstName, lastName, email, phone, comment, inviteToken } = parsed.data
 
   const event = await prisma.event.findFirst({
     where: { id: eventId, publicStatus: "published" },
@@ -110,6 +111,17 @@ export async function POST(req: Request) {
   )
 
   const editToken = registrations[0].editToken
+
+  // Mark the member invite as used (kept valid for re-visits per product
+  // decision — only the first usage is timestamped).
+  if (inviteToken) {
+    await prisma.memberInvite
+      .updateMany({
+        where: { token: inviteToken, eventId, usedAt: null },
+        data: { usedAt: new Date() },
+      })
+      .catch(() => {})
+  }
 
   const shiftData = shifts.map((s) => ({
     label: s.label,

--- a/src/app/api/public/reset-password/[token]/route.ts
+++ b/src/app/api/public/reset-password/[token]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import bcrypt from "bcryptjs"
+import { z } from "zod"
+
+const schema = z.object({
+  password: z.string().min(8).max(200),
+})
+
+/**
+ * GET — quickly check if the token is still valid before showing the form.
+ */
+export async function GET(_req: Request, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params
+  const reset = await prisma.passwordResetToken.findUnique({
+    where: { token },
+    include: { user: { select: { email: true } } },
+  })
+  if (!reset) return NextResponse.json({ error: "Lien invalide" }, { status: 404 })
+  if (reset.usedAt) return NextResponse.json({ error: "Lien déjà utilisé" }, { status: 410 })
+  if (reset.expiresAt < new Date()) return NextResponse.json({ error: "Lien expiré" }, { status: 410 })
+
+  return NextResponse.json({ email: reset.user.email })
+}
+
+/**
+ * POST — actually reset. Marks the token as used and updates the
+ * user's password hash atomically.
+ */
+export async function POST(req: Request, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params
+  const body = await req.json()
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const reset = await prisma.passwordResetToken.findUnique({ where: { token } })
+  if (!reset) return NextResponse.json({ error: "Lien invalide" }, { status: 404 })
+  if (reset.usedAt) return NextResponse.json({ error: "Lien déjà utilisé" }, { status: 410 })
+  if (reset.expiresAt < new Date()) return NextResponse.json({ error: "Lien expiré" }, { status: 410 })
+
+  const passwordHash = await bcrypt.hash(parsed.data.password, 12)
+
+  await prisma.$transaction([
+    prisma.adminUser.update({ where: { id: reset.userId }, data: { passwordHash } }),
+    prisma.passwordResetToken.update({ where: { id: reset.id }, data: { usedAt: new Date() } }),
+  ])
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/super-admin/organizations/[id]/route.ts
+++ b/src/app/api/super-admin/organizations/[id]/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server"
+import { requireSuperAdmin } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import { z } from "zod"
+
+const patchSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  isActive: z.boolean().optional(),
+})
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireSuperAdmin()
+  if (guard instanceof NextResponse) return guard
+
+  const { id } = await params
+
+  const org = await prisma.organization.findUnique({
+    where: { id },
+    include: {
+      admins: {
+        select: { id: true, email: true, name: true, role: true, isActive: true, createdAt: true },
+        orderBy: { createdAt: "asc" },
+      },
+      invitations: {
+        where: { acceptedAt: null, revokedAt: null, expiresAt: { gt: new Date() } },
+        orderBy: { createdAt: "desc" },
+      },
+      _count: { select: { events: true, members: true } },
+    },
+  })
+
+  if (!org) return NextResponse.json({ error: "Non trouvé" }, { status: 404 })
+  return NextResponse.json(org)
+}
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireSuperAdmin()
+  if (guard instanceof NextResponse) return guard
+
+  const { id } = await params
+  const body = await req.json()
+  const parsed = patchSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const org = await prisma.organization.update({ where: { id }, data: parsed.data })
+  return NextResponse.json(org)
+}
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const guard = await requireSuperAdmin()
+  if (guard instanceof NextResponse) return guard
+
+  const { id } = await params
+
+  // Soft delete: deactivate the org and all its admins. Hard delete is
+  // gated behind an explicit super admin tool to avoid accidental data
+  // loss (events + members + registrations cascade through Org FK).
+  await prisma.$transaction([
+    prisma.organization.update({ where: { id }, data: { isActive: false } }),
+    prisma.adminUser.updateMany({ where: { organizationId: id }, data: { isActive: false } }),
+  ])
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/super-admin/organizations/route.ts
+++ b/src/app/api/super-admin/organizations/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server"
+import { requireSuperAdmin } from "@/lib/auth-guard"
+import { prisma } from "@/lib/prisma"
+import { sendNotification } from "@/lib/notifications"
+import { z } from "zod"
+
+const slugRegex = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
+
+const createSchema = z.object({
+  name: z.string().min(1).max(120),
+  slug: z.string().min(2).max(60).regex(slugRegex, "Slug invalide (a-z, 0-9, tirets)"),
+  inviteEmail: z.string().email().optional(),
+})
+
+export async function GET() {
+  const guard = await requireSuperAdmin()
+  if (guard instanceof NextResponse) return guard
+
+  const orgs = await prisma.organization.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      _count: { select: { events: true, members: true, admins: true } },
+    },
+  })
+
+  return NextResponse.json(orgs)
+}
+
+export async function POST(req: Request) {
+  const guard = await requireSuperAdmin()
+  if (guard instanceof NextResponse) return guard
+  const { session } = guard
+
+  const body = await req.json()
+  const parsed = createSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+
+  const existing = await prisma.organization.findUnique({ where: { slug: parsed.data.slug } })
+  if (existing) {
+    return NextResponse.json({ error: "Ce slug est déjà utilisé" }, { status: 409 })
+  }
+
+  const org = await prisma.organization.create({
+    data: { name: parsed.data.name, slug: parsed.data.slug },
+  })
+
+  // Optional: send invitation to the first admin
+  let invitation: { id: string; email: string; token: string } | null = null
+  if (parsed.data.inviteEmail) {
+    const expiresAt = new Date(Date.now() + 7 * 24 * 3600 * 1000)
+    const created = await prisma.adminInvitation.create({
+      data: {
+        email: parsed.data.inviteEmail,
+        organizationId: org.id,
+        invitedBy: session.user.id!,
+        expiresAt,
+      },
+    })
+    invitation = { id: created.id, email: created.email, token: created.token }
+
+    await sendNotification({
+      kind: "admin_invitation",
+      recipient: { email: parsed.data.inviteEmail },
+      data: {
+        organizationName: org.name,
+        inviterName: session.user.name ?? "Un super admin",
+        token: created.token,
+        expiresAt,
+      },
+    })
+  }
+
+  return NextResponse.json({ ...org, invitation }, { status: 201 })
+}

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { useParams, useRouter } from "next/navigation"
+import { useParams, useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { formatDate, shiftsOverlap } from "@/lib/utils"
 import DayTimeline, { fmt } from "@/components/DayTimeline"
@@ -41,7 +41,9 @@ type EventData = {
 export default function EventPage() {
   const params = useParams()
   const router = useRouter()
+  const searchParams = useSearchParams()
   const slug = params.slug as string
+  const inviteToken = searchParams.get("token")
 
   type MyReg = { shiftId: string; token: string; label: string; roleName: string; startTime: string; endTime: string }
 
@@ -68,6 +70,28 @@ export default function EventPage() {
         setLoading(false)
       })
   }, [slug])
+
+  // Pre-fill from a MemberInvite token (?token=xxx in the email link).
+  // Skipped if the visitor already has a session token in localStorage —
+  // their existing registration data takes precedence.
+  useEffect(() => {
+    if (!inviteToken) return
+    const sessionToken = localStorage.getItem(`benevoles_token_${slug}`)
+    if (sessionToken) return
+    fetch(`/api/public/member-invite/${inviteToken}?slug=${encodeURIComponent(slug)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!data?.member) return
+        setForm((f) => ({
+          ...f,
+          firstName: f.firstName || data.member.firstName,
+          lastName: f.lastName || data.member.lastName,
+          email: f.email || data.member.email,
+          phone: f.phone || data.member.phone,
+        }))
+      })
+      .catch(() => {})
+  }, [inviteToken, slug])
 
   useEffect(() => {
     const token = localStorage.getItem(`benevoles_token_${slug}`)
@@ -151,6 +175,7 @@ export default function EventPage() {
         eventId: event!.id,
         shiftIds: Array.from(selectedShifts).filter((id) => !myShiftIds.has(id)),
         ...form,
+        inviteToken: inviteToken ?? undefined,
       }),
     })
 

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import Link from "next/link"
+
+type Preview = {
+  email: string
+  organizationName: string
+}
+
+export default function AcceptInvitationPage() {
+  const params = useParams()
+  const router = useRouter()
+  const token = params.token as string
+
+  const [preview, setPreview] = useState<Preview | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const [name, setName] = useState("")
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    fetch(`/api/public/invitations/${token}`)
+      .then(async (r) => {
+        const data = await r.json().catch(() => ({}))
+        if (r.ok) setPreview(data as Preview)
+        else setLoadError(data.error ?? "Lien invalide")
+      })
+      .finally(() => setLoading(false))
+  }, [token])
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    if (password !== confirm) {
+      setError("Les mots de passe ne correspondent pas")
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    const res = await fetch(`/api/public/invitations/${token}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, password }),
+    })
+    setSubmitting(false)
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setError(typeof data?.error === "string" ? data.error : "Erreur lors de la création du compte")
+      return
+    }
+    setSuccess(true)
+    setTimeout(() => router.push("/admin/login"), 1500)
+  }
+
+  if (loading) {
+    return <Center>Chargement…</Center>
+  }
+
+  if (loadError) {
+    return (
+      <Center>
+        <h1 className="text-lg font-semibold text-gray-700 mb-2">Invitation invalide</h1>
+        <p className="text-sm text-gray-500 mb-6">{loadError}</p>
+        <Link href="/" className="text-blue-600 text-sm">Retour à l&apos;accueil</Link>
+      </Center>
+    )
+  }
+
+  if (success) {
+    return (
+      <Center>
+        <h1 className="text-lg font-semibold text-green-700 mb-2">Compte créé !</h1>
+        <p className="text-sm text-gray-500">Redirection vers la connexion…</p>
+      </Center>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4 py-8">
+      <div className="bg-white rounded-2xl border border-gray-200 p-6 max-w-md w-full">
+        <h1 className="text-xl font-bold text-gray-900 mb-2">Bienvenue !</h1>
+        <p className="text-sm text-gray-600 mb-6">
+          Tu rejoins <strong>{preview?.organizationName}</strong> en tant qu&apos;administrateur.
+        </p>
+
+        <form onSubmit={submit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <input
+              type="email"
+              value={preview?.email ?? ""}
+              disabled
+              className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm bg-gray-50 text-gray-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Ton nom *</label>
+            <input
+              type="text"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Prénom Nom"
+              className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Mot de passe *</label>
+            <input
+              type="password"
+              required
+              minLength={8}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <p className="text-xs text-gray-500 mt-1">8 caractères minimum.</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Confirmer *</label>
+            <input
+              type="password"
+              required
+              minLength={8}
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700">{error}</div>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full bg-blue-600 text-white rounded-2xl py-3 text-sm font-semibold hover:bg-blue-700 disabled:opacity-50"
+          >
+            {submitting ? "Création…" : "Créer mon compte"}
+          </button>
+        </form>
+      </div>
+    </main>
+  )
+}
+
+function Center({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="bg-white rounded-2xl border border-gray-200 p-8 text-center max-w-md w-full">
+        {children}
+      </div>
+    </main>
+  )
+}

--- a/src/app/super-admin/layout.tsx
+++ b/src/app/super-admin/layout.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation"
+import { auth } from "@/auth"
+import SuperAdminNav from "@/components/admin/SuperAdminNav"
+
+export default async function SuperAdminLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth()
+  if (!session?.user) redirect("/admin/login")
+  if (session.user.role !== "super_admin") redirect("/admin")
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <SuperAdminNav userName={session.user.name ?? "Super admin"} />
+      <main className="max-w-5xl mx-auto px-4 py-6">{children}</main>
+    </div>
+  )
+}

--- a/src/app/super-admin/organizations/new/page.tsx
+++ b/src/app/super-admin/organizations/new/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link"
+import { redirect } from "next/navigation"
+import { auth } from "@/auth"
+import NewOrganizationForm from "@/components/admin/NewOrganizationForm"
+
+export const dynamic = "force-dynamic"
+
+export default async function NewOrganizationPage() {
+  const session = await auth()
+  if (!session?.user || session.user.role !== "super_admin") redirect("/admin")
+
+  return (
+    <div className="max-w-xl space-y-5">
+      <Link href="/super-admin/organizations" className="text-sm text-purple-600">← Retour</Link>
+      <h1 className="text-xl font-bold text-gray-900">Nouvelle organisation</h1>
+      <NewOrganizationForm />
+    </div>
+  )
+}

--- a/src/app/super-admin/organizations/page.tsx
+++ b/src/app/super-admin/organizations/page.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link"
+import { redirect } from "next/navigation"
+import { auth } from "@/auth"
+import { prisma } from "@/lib/prisma"
+import OrganizationsManager from "@/components/admin/OrganizationsManager"
+
+export const dynamic = "force-dynamic"
+
+export default async function OrganizationsPage() {
+  const session = await auth()
+  if (!session?.user || session.user.role !== "super_admin") redirect("/admin")
+
+  const orgs = await prisma.organization.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      _count: { select: { events: true, members: true, admins: true } },
+    },
+  })
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">Organisations</h1>
+          <p className="text-sm text-gray-500">{orgs.length} organisation{orgs.length > 1 ? "s" : ""}</p>
+        </div>
+        <Link
+          href="/super-admin/organizations/new"
+          className="bg-purple-600 text-white px-4 py-2 rounded-xl text-sm font-medium hover:bg-purple-700"
+        >
+          + Nouvelle organisation
+        </Link>
+      </div>
+
+      <OrganizationsManager
+        orgs={orgs.map((o) => ({
+          id: o.id,
+          name: o.name,
+          slug: o.slug,
+          isActive: o.isActive,
+          createdAt: o.createdAt.toISOString(),
+          counts: o._count,
+        }))}
+      />
+    </div>
+  )
+}

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -14,11 +14,22 @@ export const authConfig: NextAuthConfig = {
       return true
     },
     jwt({ token, user }) {
-      if (user) token.role = (user as { role?: string }).role
+      if (user) {
+        const u = user as { role?: string; organizationId?: string | null }
+        token.role = u.role
+        token.organizationId = u.organizationId ?? null
+      }
       return token
     },
     session({ session, token }) {
-      if (session.user) (session.user as { role?: unknown }).role = token.role
+      if (session.user) {
+        const u = session.user as {
+          role?: string
+          organizationId?: string | null
+        }
+        u.role = token.role as string | undefined
+        u.organizationId = (token.organizationId as string | null | undefined) ?? null
+      }
       return session
     },
   },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -24,7 +24,13 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         const valid = await bcrypt.compare(credentials.password as string, user.passwordHash)
         if (!valid) return null
 
-        return { id: user.id, email: user.email, name: user.name, role: user.role }
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+          organizationId: user.organizationId,
+        }
       },
     }),
   ],

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -4,7 +4,12 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { signOut } from "next-auth/react"
 
-export default function AdminNav({ userName }: { userName: string }) {
+type Props = {
+  userName: string
+  isSuperAdmin?: boolean
+}
+
+export default function AdminNav({ userName, isSuperAdmin = false }: Props) {
   const pathname = usePathname()
 
   return (
@@ -26,6 +31,20 @@ export default function AdminNav({ userName }: { userName: string }) {
           >
             Membres
           </Link>
+          <Link
+            href="/admin/settings/members"
+            className={`text-sm ${pathname.startsWith("/admin/settings") ? "text-blue-600 font-medium" : "text-gray-500 hover:text-gray-800"}`}
+          >
+            Équipe
+          </Link>
+          {isSuperAdmin && (
+            <Link
+              href="/super-admin/organizations"
+              className="text-sm text-purple-600 font-medium hover:text-purple-800"
+            >
+              ⚙ Super admin
+            </Link>
+          )}
         </div>
         <div className="flex items-center gap-4">
           <span className="text-xs text-gray-400">{userName}</span>

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -20,6 +20,12 @@ export default function AdminNav({ userName }: { userName: string }) {
           >
             Événements
           </Link>
+          <Link
+            href="/admin/members"
+            className={`text-sm ${pathname.startsWith("/admin/members") ? "text-blue-600 font-medium" : "text-gray-500 hover:text-gray-800"}`}
+          >
+            Membres
+          </Link>
         </div>
         <div className="flex items-center gap-4">
           <span className="text-xs text-gray-400">{userName}</span>

--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -13,6 +13,7 @@ type EventFormData = {
   endDate: string
   publicInstructions: string
   confirmationMessage: string
+  reminderMessage: string
   publicStatus: "draft" | "published" | "archived"
 }
 
@@ -28,6 +29,7 @@ const defaultData: EventFormData = {
   endDate: "",
   publicInstructions: "",
   confirmationMessage: "Merci pour votre inscription ! À bientôt.",
+  reminderMessage: "",
   publicStatus: "draft",
 }
 
@@ -296,6 +298,15 @@ export default function EventForm({ initialData }: Props) {
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">Message de confirmation</label>
           <textarea rows={2} value={form.confirmationMessage} onChange={(e) => set("confirmationMessage", e.target.value)}
+            className={`${inputCls} resize-none`} />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Message de rappel <span className="text-gray-400 font-normal">(envoyé manuellement avant l&apos;événement)</span>
+          </label>
+          <textarea rows={3} value={form.reminderMessage} onChange={(e) => set("reminderMessage", e.target.value)}
+            placeholder="Consignes vestimentaires, point de RDV, accès, parking…"
             className={`${inputCls} resize-none`} />
         </div>
 

--- a/src/components/admin/InvitationsManager.tsx
+++ b/src/components/admin/InvitationsManager.tsx
@@ -1,0 +1,361 @@
+"use client"
+
+import { useMemo, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+
+type Member = {
+  id: string
+  firstName: string
+  lastName: string
+  email: string | null
+  tags: string[]
+}
+
+type Invite = {
+  id: string
+  sentAt: string
+  usedAt: string | null
+  memberId: string
+  firstName: string
+  lastName: string
+  email: string | null
+  tags: string[]
+  registered: boolean
+}
+
+type Props = {
+  eventId: string
+  members: Member[]
+  allTags: string[]
+  invites: Invite[]
+}
+
+export default function InvitationsManager({ eventId, members, allTags, invites }: Props) {
+  const router = useRouter()
+  const [showInvite, setShowInvite] = useState(false)
+  const [, startTransition] = useTransition()
+  const [reminding, setReminding] = useState(false)
+  const [remindResult, setRemindResult] = useState<string | null>(null)
+
+  const total = invites.length
+  const registered = invites.filter((i) => i.registered).length
+  const noAnswer = total - registered
+
+  function refresh() {
+    startTransition(() => router.refresh())
+  }
+
+  async function remindNonRegistered() {
+    if (!confirm(`Envoyer une relance aux ${noAnswer} membres invités sans réponse ?`)) return
+    setReminding(true)
+    setRemindResult(null)
+    const res = await fetch(`/api/admin/events/${eventId}/invitations/remind`, { method: "POST" })
+    setReminding(false)
+    if (!res.ok) {
+      setRemindResult("Erreur lors de l'envoi des relances")
+      return
+    }
+    const data = await res.json()
+    setRemindResult(`${data.sent} relance${data.sent > 1 ? "s" : ""} envoyée${data.sent > 1 ? "s" : ""}`)
+    refresh()
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-3 gap-3">
+        <StatCard label="Invités" value={total} />
+        <StatCard label="Inscrits" value={registered} positive={registered > 0} />
+        <StatCard label="Sans réponse" value={noAnswer} warning={noAnswer > 0} />
+      </div>
+
+      <div className="flex gap-2 flex-wrap">
+        <button
+          onClick={() => setShowInvite(true)}
+          className="bg-blue-600 text-white px-4 py-2 rounded-xl text-sm font-medium hover:bg-blue-700"
+        >
+          + Inviter des membres
+        </button>
+        {noAnswer > 0 && (
+          <button
+            onClick={remindNonRegistered}
+            disabled={reminding}
+            className="text-sm border border-gray-200 px-3 py-2 rounded-xl hover:bg-gray-50 disabled:opacity-50"
+          >
+            {reminding ? "Envoi…" : `Relancer les ${noAnswer} sans réponse`}
+          </button>
+        )}
+        {remindResult && <span className="text-sm text-gray-600 self-center">{remindResult}</span>}
+      </div>
+
+      {invites.length === 0 ? (
+        <div className="bg-white border border-gray-200 rounded-xl p-10 text-center text-gray-400">
+          Aucune invitation envoyée pour cet événement.
+        </div>
+      ) : (
+        <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs text-gray-500 uppercase tracking-wide">
+              <tr>
+                <th className="text-left px-4 py-2 font-medium">Membre</th>
+                <th className="text-left px-4 py-2 font-medium">Tags</th>
+                <th className="text-left px-4 py-2 font-medium">Invité le</th>
+                <th className="text-left px-4 py-2 font-medium">Statut</th>
+              </tr>
+            </thead>
+            <tbody>
+              {invites.map((i) => {
+                const date = new Date(i.sentAt).toLocaleDateString("fr-FR")
+                return (
+                  <tr key={i.id} className="border-t border-gray-100">
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-gray-900">{i.firstName} {i.lastName}</div>
+                      {i.email ? (
+                        <div className="text-xs text-gray-500">{i.email}</div>
+                      ) : (
+                        <div className="text-xs text-orange-500">⚠ pas d&apos;email</div>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {i.tags.map((t) => (
+                          <span key={t} className="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full">
+                            {t}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 text-xs">{date}</td>
+                    <td className="px-4 py-3">
+                      {i.registered ? (
+                        <span className="text-xs font-medium text-green-700 bg-green-50 px-2 py-1 rounded-full">
+                          ✓ Inscrit·e
+                        </span>
+                      ) : (
+                        <span className="text-xs text-gray-500 bg-gray-50 px-2 py-1 rounded-full">
+                          Sans réponse
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {showInvite && (
+        <InviteModal
+          eventId={eventId}
+          members={members}
+          allTags={allTags}
+          alreadyInvitedIds={new Set(invites.map((i) => i.memberId))}
+          onClose={() => setShowInvite(false)}
+          onDone={() => {
+            setShowInvite(false)
+            refresh()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function InviteModal({
+  eventId,
+  members,
+  allTags,
+  alreadyInvitedIds,
+  onClose,
+  onDone,
+}: {
+  eventId: string
+  members: Member[]
+  allTags: string[]
+  alreadyInvitedIds: Set<string>
+  onClose: () => void
+  onDone: () => void
+}) {
+  const [search, setSearch] = useState("")
+  const [tagFilter, setTagFilter] = useState("")
+  const [hideInvited, setHideInvited] = useState(true)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [message, setMessage] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<string | null>(null)
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return members.filter((m) => {
+      if (hideInvited && alreadyInvitedIds.has(m.id)) return false
+      if (tagFilter && !m.tags.includes(tagFilter)) return false
+      if (!q) return true
+      return (
+        m.firstName.toLowerCase().includes(q) ||
+        m.lastName.toLowerCase().includes(q) ||
+        (m.email ?? "").toLowerCase().includes(q)
+      )
+    })
+  }, [members, search, tagFilter, hideInvited, alreadyInvitedIds])
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function selectAllVisible() {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      for (const m of filtered) next.add(m.id)
+      return next
+    })
+  }
+
+  function clearSelection() {
+    setSelected(new Set())
+  }
+
+  async function submit() {
+    if (selected.size === 0) return
+    setSubmitting(true)
+    setResult(null)
+    const res = await fetch(`/api/admin/events/${eventId}/invitations`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        memberIds: Array.from(selected),
+        message: message.trim() || undefined,
+      }),
+    })
+    setSubmitting(false)
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setResult(typeof data?.error === "string" ? data.error : "Erreur lors de l'envoi")
+      return
+    }
+    const data = await res.json()
+    const parts: string[] = []
+    if (data.invitedNew) parts.push(`${data.invitedNew} invités`)
+    if (data.skippedExisting) parts.push(`${data.skippedExisting} déjà invités`)
+    if (data.emailsSent) parts.push(`${data.emailsSent} emails envoyés`)
+    if (data.membersWithoutEmail) parts.push(`${data.membersWithoutEmail} sans email`)
+    setResult(parts.join(" · "))
+    setTimeout(onDone, 1500)
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4" onClick={onClose}>
+      <div
+        className="bg-white rounded-2xl p-5 max-w-2xl w-full max-h-[85vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-semibold text-gray-900">Inviter des membres</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none">×</button>
+        </div>
+
+        <div className="flex flex-wrap gap-2 mb-3">
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Rechercher…"
+            className="flex-1 min-w-[180px] border border-gray-200 rounded-lg px-3 py-1.5 text-sm"
+          />
+          <select
+            value={tagFilter}
+            onChange={(e) => setTagFilter(e.target.value)}
+            className="border border-gray-200 rounded-lg px-3 py-1.5 text-sm"
+          >
+            <option value="">Tous les tags</option>
+            {allTags.map((t) => <option key={t} value={t}>{t}</option>)}
+          </select>
+          <label className="text-xs text-gray-600 flex items-center gap-1">
+            <input type="checkbox" checked={hideInvited} onChange={(e) => setHideInvited(e.target.checked)} />
+            Cacher déjà invités
+          </label>
+        </div>
+
+        <div className="flex justify-between text-xs text-gray-500 mb-2">
+          <span>{filtered.length} membres affichés · {selected.size} sélectionnés</span>
+          <div className="flex gap-2">
+            <button onClick={selectAllVisible} className="text-blue-600 hover:underline">Tout sélectionner</button>
+            <button onClick={clearSelection} className="text-gray-500 hover:underline">Effacer</button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto border border-gray-200 rounded-xl">
+          {filtered.length === 0 ? (
+            <div className="p-8 text-center text-sm text-gray-400">Aucun membre à inviter</div>
+          ) : (
+            <ul className="divide-y divide-gray-100">
+              {filtered.map((m) => (
+                <li key={m.id} className="flex items-center gap-3 p-3">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(m.id)}
+                    onChange={() => toggle(m.id)}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium text-gray-900">{m.firstName} {m.lastName}</div>
+                    <div className="text-xs text-gray-500 truncate">
+                      {m.email ?? <span className="text-orange-500">pas d&apos;email</span>}
+                      {m.tags.length > 0 && <> · {m.tags.join(", ")}</>}
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="mt-4 space-y-3">
+          <div>
+            <label className="block text-sm text-gray-700 mb-1">Message (optionnel)</label>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              maxLength={500}
+              rows={2}
+              placeholder="Un mot d'accompagnement court qui sera inclus dans l'email"
+              className="w-full border border-gray-200 rounded-lg px-3 py-1.5 text-sm"
+            />
+          </div>
+
+          {result && <div className="text-sm text-gray-700 bg-gray-50 px-3 py-2 rounded-lg">{result}</div>}
+
+          <div className="flex justify-end gap-2">
+            <button type="button" onClick={onClose} className="text-sm px-4 py-2 text-gray-600 hover:text-gray-900">
+              Annuler
+            </button>
+            <button
+              onClick={submit}
+              disabled={selected.size === 0 || submitting}
+              className="bg-blue-600 text-white text-sm px-4 py-2 rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? "Envoi…" : `Envoyer ${selected.size} invitation${selected.size > 1 ? "s" : ""}`}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function StatCard({ label, value, positive, warning }: { label: string; value: number; positive?: boolean; warning?: boolean }) {
+  const color = positive
+    ? "bg-green-50 border-green-200 text-green-700"
+    : warning
+      ? "bg-orange-50 border-orange-200 text-orange-700"
+      : "bg-white border-gray-200 text-gray-900"
+  return (
+    <div className={`rounded-xl border p-4 text-center ${color}`}>
+      <p className="text-2xl font-bold">{value}</p>
+      <p className="text-xs mt-1 opacity-70">{label}</p>
+    </div>
+  )
+}

--- a/src/components/admin/MembersManager.tsx
+++ b/src/components/admin/MembersManager.tsx
@@ -21,7 +21,9 @@ type Props = {
 
 export default function MembersManager({ initialMembers, allTags }: Props) {
   const router = useRouter()
-  const [members, setMembers] = useState(initialMembers)
+  // No local state for members: derive from props directly so a
+  // router.refresh() (after import / deactivate) shows the new list.
+  const members = initialMembers
   const [search, setSearch] = useState("")
   const [tagFilter, setTagFilter] = useState<string>("")
   const [showInactive, setShowInactive] = useState(false)
@@ -51,9 +53,7 @@ export default function MembersManager({ initialMembers, allTags }: Props) {
   async function deactivate(id: string) {
     if (!confirm("Désactiver ce membre ?")) return
     const res = await fetch(`/api/admin/members/${id}`, { method: "DELETE" })
-    if (res.ok) {
-      setMembers((prev) => prev.map((m) => (m.id === id ? { ...m, active: false } : m)))
-    }
+    if (res.ok) refresh()
   }
 
   return (

--- a/src/components/admin/MembersManager.tsx
+++ b/src/components/admin/MembersManager.tsx
@@ -1,0 +1,406 @@
+"use client"
+
+import { useMemo, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+
+type Member = {
+  id: string
+  firstName: string
+  lastName: string
+  email: string | null
+  phone: string | null
+  tags: string[]
+  active: boolean
+  notes: string | null
+}
+
+type Props = {
+  initialMembers: Member[]
+  allTags: string[]
+}
+
+export default function MembersManager({ initialMembers, allTags }: Props) {
+  const router = useRouter()
+  const [members, setMembers] = useState(initialMembers)
+  const [search, setSearch] = useState("")
+  const [tagFilter, setTagFilter] = useState<string>("")
+  const [showInactive, setShowInactive] = useState(false)
+  const [showAdd, setShowAdd] = useState(false)
+  const [showImport, setShowImport] = useState(false)
+  const [, startTransition] = useTransition()
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return members.filter((m) => {
+      if (!showInactive && !m.active) return false
+      if (tagFilter && !m.tags.includes(tagFilter)) return false
+      if (!q) return true
+      return (
+        m.firstName.toLowerCase().includes(q) ||
+        m.lastName.toLowerCase().includes(q) ||
+        (m.email ?? "").toLowerCase().includes(q) ||
+        (m.phone ?? "").toLowerCase().includes(q)
+      )
+    })
+  }, [members, search, tagFilter, showInactive])
+
+  function refresh() {
+    startTransition(() => router.refresh())
+  }
+
+  async function deactivate(id: string) {
+    if (!confirm("Désactiver ce membre ?")) return
+    const res = await fetch(`/api/admin/members/${id}`, { method: "DELETE" })
+    if (res.ok) {
+      setMembers((prev) => prev.map((m) => (m.id === id ? { ...m, active: false } : m)))
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">Membres</h1>
+          <p className="text-sm text-gray-500">{members.length} membre{members.length > 1 ? "s" : ""}</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setShowImport(true)}
+            className="text-sm border border-gray-200 px-3 py-1.5 rounded-lg hover:bg-gray-50"
+          >
+            Importer CSV/Excel
+          </button>
+          <button
+            onClick={() => setShowAdd(true)}
+            className="bg-blue-600 text-white px-4 py-2 rounded-xl text-sm font-medium hover:bg-blue-700"
+          >
+            + Nouveau membre
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-white border border-gray-200 rounded-xl p-3 flex flex-wrap items-center gap-3">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Rechercher (nom, email, téléphone)…"
+          className="flex-1 min-w-[200px] border border-gray-200 rounded-lg px-3 py-1.5 text-sm"
+        />
+        <select
+          value={tagFilter}
+          onChange={(e) => setTagFilter(e.target.value)}
+          className="border border-gray-200 rounded-lg px-3 py-1.5 text-sm"
+        >
+          <option value="">Tous les tags</option>
+          {allTags.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+        <label className="text-sm text-gray-600 flex items-center gap-1.5">
+          <input type="checkbox" checked={showInactive} onChange={(e) => setShowInactive(e.target.checked)} />
+          Inclure inactifs
+        </label>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-16 text-gray-400">
+          {members.length === 0
+            ? "Aucun membre. Ajoute-en un ou importe ton fichier Excel."
+            : "Aucun membre ne correspond aux filtres."}
+        </div>
+      ) : (
+        <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs text-gray-500 uppercase tracking-wide">
+              <tr>
+                <th className="text-left px-4 py-2 font-medium">Nom</th>
+                <th className="text-left px-4 py-2 font-medium">Contact</th>
+                <th className="text-left px-4 py-2 font-medium">Tags</th>
+                <th className="text-right px-4 py-2 font-medium"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((m) => (
+                <tr key={m.id} className={`border-t border-gray-100 ${!m.active ? "opacity-50" : ""}`}>
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-gray-900">{m.firstName} {m.lastName}</div>
+                    {!m.active && <div className="text-xs text-gray-400">inactif</div>}
+                  </td>
+                  <td className="px-4 py-3 text-gray-600">
+                    {m.email && <div className="text-xs">{m.email}</div>}
+                    {m.phone && <div className="text-xs text-gray-400">{m.phone}</div>}
+                    {!m.email && !m.phone && <span className="text-xs text-gray-300">—</span>}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {m.tags.map((t) => (
+                        <span key={t} className="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full">
+                          {t}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    {m.active && (
+                      <button
+                        onClick={() => deactivate(m.id)}
+                        className="text-xs text-gray-400 hover:text-red-600"
+                      >
+                        Désactiver
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {showAdd && <AddMemberModal onClose={() => setShowAdd(false)} onCreated={refresh} />}
+      {showImport && <ImportModal onClose={() => setShowImport(false)} onImported={refresh} />}
+    </div>
+  )
+}
+
+function AddMemberModal({ onClose, onCreated }: { onClose: () => void; onCreated: () => void }) {
+  const [firstName, setFirstName] = useState("")
+  const [lastName, setLastName] = useState("")
+  const [email, setEmail] = useState("")
+  const [phone, setPhone] = useState("")
+  const [tags, setTags] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    const res = await fetch("/api/admin/members", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        firstName,
+        lastName,
+        email: email || undefined,
+        phone: phone || undefined,
+        tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+      }),
+    })
+    setSubmitting(false)
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setError(typeof data?.error === "string" ? data.error : "Erreur lors de la création")
+      return
+    }
+    onCreated()
+    onClose()
+  }
+
+  return (
+    <ModalShell title="Nouveau membre" onClose={onClose}>
+      <form onSubmit={submit} className="space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Prénom" required value={firstName} onChange={setFirstName} />
+          <Field label="Nom" required value={lastName} onChange={setLastName} />
+        </div>
+        <Field label="Email" type="email" value={email} onChange={setEmail} />
+        <Field label="Téléphone" value={phone} onChange={setPhone} />
+        <Field label="Tags (séparés par des virgules)" value={tags} onChange={setTags} placeholder="parent CM2, bar" />
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="text-sm px-4 py-2 text-gray-600 hover:text-gray-900">
+            Annuler
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="bg-blue-600 text-white text-sm px-4 py-2 rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50"
+          >
+            {submitting ? "…" : "Créer"}
+          </button>
+        </div>
+      </form>
+    </ModalShell>
+  )
+}
+
+function ImportModal({ onClose, onImported }: { onClose: () => void; onImported: () => void }) {
+  const [file, setFile] = useState<File | null>(null)
+  const [onDuplicate, setOnDuplicate] = useState<"skip" | "update">("skip")
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<{
+    created: number
+    updated: number
+    skipped: number
+    errors: { line: number; reason: string }[]
+    detectedColumns: Record<string, string | null>
+    totalParsed: number
+  } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!file) return
+    setSubmitting(true)
+    setError(null)
+    const fd = new FormData()
+    fd.append("file", file)
+    fd.append("onDuplicate", onDuplicate)
+    const res = await fetch("/api/admin/members/import", { method: "POST", body: fd })
+    setSubmitting(false)
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setError(typeof data?.error === "string" ? data.error : "Erreur lors de l'import")
+      return
+    }
+    const data = await res.json()
+    setResult(data)
+  }
+
+  return (
+    <ModalShell title="Importer des membres" onClose={onClose}>
+      {!result ? (
+        <form onSubmit={submit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-700 mb-1">Fichier CSV ou Excel</label>
+            <input
+              type="file"
+              accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              required
+              className="text-sm w-full"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Colonnes attendues : prénom, nom, email, téléphone, tags. Les variantes courantes sont reconnues.
+            </p>
+          </div>
+          <div>
+            <label className="block text-sm text-gray-700 mb-1">Si un email existe déjà</label>
+            <div className="flex gap-3">
+              <label className="text-sm text-gray-700 flex items-center gap-1.5">
+                <input
+                  type="radio"
+                  checked={onDuplicate === "skip"}
+                  onChange={() => setOnDuplicate("skip")}
+                />
+                Ignorer
+              </label>
+              <label className="text-sm text-gray-700 flex items-center gap-1.5">
+                <input
+                  type="radio"
+                  checked={onDuplicate === "update"}
+                  onChange={() => setOnDuplicate("update")}
+                />
+                Mettre à jour
+              </label>
+            </div>
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <div className="flex justify-end gap-2">
+            <button type="button" onClick={onClose} className="text-sm px-4 py-2 text-gray-600 hover:text-gray-900">
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={!file || submitting}
+              className="bg-blue-600 text-white text-sm px-4 py-2 rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? "Import en cours…" : "Importer"}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="space-y-4">
+          <div className="bg-green-50 border border-green-200 rounded-xl p-3 text-sm text-green-800">
+            <strong>{result.created}</strong> créés, <strong>{result.updated}</strong> mis à jour, <strong>{result.skipped}</strong> ignorés ({result.totalParsed} lignes lues)
+          </div>
+          {result.errors.length > 0 && (
+            <div className="bg-orange-50 border border-orange-200 rounded-xl p-3 text-sm text-orange-800">
+              <p className="font-medium mb-2">{result.errors.length} ligne{result.errors.length > 1 ? "s" : ""} ignorée{result.errors.length > 1 ? "s" : ""} :</p>
+              <ul className="text-xs space-y-1 max-h-40 overflow-y-auto">
+                {result.errors.slice(0, 50).map((e, i) => (
+                  <li key={i}>
+                    {e.line > 0 ? `Ligne ${e.line} : ` : ""}
+                    {e.reason}
+                  </li>
+                ))}
+                {result.errors.length > 50 && <li>… et {result.errors.length - 50} autres</li>}
+              </ul>
+            </div>
+          )}
+          <div className="text-xs text-gray-500">
+            Colonnes détectées :
+            {Object.entries(result.detectedColumns).map(([k, v]) => (
+              <span key={k} className="ml-2">{k} → {v ?? "—"}</span>
+            ))}
+          </div>
+          <div className="flex justify-end">
+            <button
+              onClick={() => {
+                onImported()
+                onClose()
+              }}
+              className="bg-blue-600 text-white text-sm px-4 py-2 rounded-xl font-medium hover:bg-blue-700"
+            >
+              Fermer
+            </button>
+          </div>
+        </div>
+      )}
+    </ModalShell>
+  )
+}
+
+function ModalShell({
+  title,
+  onClose,
+  children,
+}: {
+  title: string
+  onClose: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4" onClick={onClose}>
+      <div className="bg-white rounded-2xl p-5 max-w-lg w-full" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none">×</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  type = "text",
+  required = false,
+  placeholder,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  type?: string
+  required?: boolean
+  placeholder?: string
+}) {
+  return (
+    <div>
+      <label className="block text-sm text-gray-700 mb-1">{label}{required && " *"}</label>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        required={required}
+        placeholder={placeholder}
+        className="w-full border border-gray-200 rounded-lg px-3 py-1.5 text-sm"
+      />
+    </div>
+  )
+}

--- a/src/components/admin/NewOrganizationForm.tsx
+++ b/src/components/admin/NewOrganizationForm.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+}
+
+export default function NewOrganizationForm() {
+  const router = useRouter()
+  const [name, setName] = useState("")
+  const [slug, setSlug] = useState("")
+  const [slugManual, setSlugManual] = useState(false)
+  const [inviteEmail, setInviteEmail] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function handleNameChange(value: string) {
+    setName(value)
+    if (!slugManual) setSlug(slugify(value))
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+
+    const res = await fetch("/api/super-admin/organizations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name,
+        slug,
+        inviteEmail: inviteEmail || undefined,
+      }),
+    })
+    setSubmitting(false)
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setError(typeof data?.error === "string" ? data.error : "Erreur lors de la création")
+      return
+    }
+
+    router.push("/super-admin/organizations")
+    router.refresh()
+  }
+
+  return (
+    <form onSubmit={submit} className="bg-white border border-gray-200 rounded-2xl p-6 space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Nom *</label>
+        <input
+          type="text"
+          required
+          value={name}
+          onChange={(e) => handleNameChange(e.target.value)}
+          placeholder="ex: École de Cirque de Lutry"
+          className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Slug * <span className="text-gray-400 font-normal">(URL, généré automatiquement)</span>
+        </label>
+        <input
+          type="text"
+          required
+          value={slug}
+          onChange={(e) => { setSlug(e.target.value); setSlugManual(true) }}
+          pattern="[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+          minLength={2}
+          maxLength={60}
+          className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Email du premier admin <span className="text-gray-400 font-normal">(optionnel)</span>
+        </label>
+        <input
+          type="email"
+          value={inviteEmail}
+          onChange={(e) => setInviteEmail(e.target.value)}
+          placeholder="président@asso.dev"
+          className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        />
+        <p className="text-xs text-gray-500 mt-1">Si renseigné, une invitation est envoyée pour qu'il crée son compte.</p>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700">{error}</div>
+      )}
+
+      <div className="flex justify-end gap-2 pt-2">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="bg-purple-600 text-white px-5 py-2.5 rounded-xl text-sm font-medium hover:bg-purple-700 disabled:opacity-50"
+        >
+          {submitting ? "Création…" : "Créer l'organisation"}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/admin/OrganizationsManager.tsx
+++ b/src/components/admin/OrganizationsManager.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useTransition } from "react"
+
+type Org = {
+  id: string
+  name: string
+  slug: string
+  isActive: boolean
+  createdAt: string
+  counts: { events: number; members: number; admins: number }
+}
+
+export default function OrganizationsManager({ orgs }: { orgs: Org[] }) {
+  const router = useRouter()
+  const [, startTransition] = useTransition()
+
+  async function toggleActive(id: string, isActive: boolean) {
+    const verb = isActive ? "Réactiver" : "Désactiver"
+    if (!confirm(`${verb} cette organisation ?`)) return
+    const res = await fetch(`/api/super-admin/organizations/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ isActive }),
+    })
+    if (res.ok) startTransition(() => router.refresh())
+  }
+
+  if (orgs.length === 0) {
+    return (
+      <div className="text-center py-16 text-gray-400">
+        Aucune organisation. Crée la première.
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50 text-xs text-gray-500 uppercase tracking-wide">
+          <tr>
+            <th className="text-left px-4 py-2 font-medium">Nom</th>
+            <th className="text-left px-4 py-2 font-medium">Slug</th>
+            <th className="text-center px-4 py-2 font-medium">Events</th>
+            <th className="text-center px-4 py-2 font-medium">Membres</th>
+            <th className="text-center px-4 py-2 font-medium">Admins</th>
+            <th className="text-left px-4 py-2 font-medium">Statut</th>
+            <th className="text-right px-4 py-2 font-medium"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {orgs.map((o) => (
+            <tr key={o.id} className={`border-t border-gray-100 ${!o.isActive ? "opacity-50" : ""}`}>
+              <td className="px-4 py-3">
+                <Link href={`/super-admin/organizations/${o.id}`} className="font-medium text-gray-900 hover:text-purple-600">
+                  {o.name}
+                </Link>
+              </td>
+              <td className="px-4 py-3 text-gray-500 text-xs font-mono">{o.slug}</td>
+              <td className="px-4 py-3 text-center">{o.counts.events}</td>
+              <td className="px-4 py-3 text-center">{o.counts.members}</td>
+              <td className="px-4 py-3 text-center">{o.counts.admins}</td>
+              <td className="px-4 py-3">
+                {o.isActive ? (
+                  <span className="text-xs text-green-700 bg-green-50 px-2 py-0.5 rounded-full">actif</span>
+                ) : (
+                  <span className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">inactif</span>
+                )}
+              </td>
+              <td className="px-4 py-3 text-right">
+                <button
+                  onClick={() => toggleActive(o.id, !o.isActive)}
+                  className="text-xs text-gray-400 hover:text-purple-600"
+                >
+                  {o.isActive ? "Désactiver" : "Réactiver"}
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/admin/QrPrintView.tsx
+++ b/src/components/admin/QrPrintView.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import Link from "next/link"
+
+type Props = {
+  eventId: string
+  title: string
+  location: string | null
+  startDate: string
+  endDate: string
+  publicUrl: string
+  backHref: string
+}
+
+function formatDateRange(startISO: string, endISO: string) {
+  const start = new Date(startISO)
+  const end = new Date(endISO)
+  const opts: Intl.DateTimeFormatOptions = { weekday: "long", day: "numeric", month: "long", year: "numeric" }
+  if (start.toDateString() === end.toDateString()) {
+    return start.toLocaleDateString("fr-FR", opts)
+  }
+  return `${start.toLocaleDateString("fr-FR", opts)} → ${end.toLocaleDateString("fr-FR", opts)}`
+}
+
+export default function QrPrintView({
+  eventId,
+  title,
+  location,
+  startDate,
+  endDate,
+  publicUrl,
+  backHref,
+}: Props) {
+  const pngUrl = `/api/admin/events/${eventId}/qr?format=png`
+  const svgUrl = `/api/admin/events/${eventId}/qr?format=svg`
+
+  return (
+    <div className="space-y-5">
+      <div className="no-print flex items-center justify-between flex-wrap gap-3">
+        <div>
+          <Link href={backHref} className="text-sm text-blue-600">← Retour à l&apos;événement</Link>
+          <h1 className="text-xl font-bold text-gray-900 mt-1">QR code</h1>
+        </div>
+        <div className="flex gap-2">
+          <a
+            href={pngUrl}
+            download={`qr-${eventId}.png`}
+            className="text-sm border border-gray-200 px-3 py-1.5 rounded-lg hover:bg-gray-50"
+          >
+            Télécharger PNG
+          </a>
+          <a
+            href={svgUrl}
+            download={`qr-${eventId}.svg`}
+            className="text-sm border border-gray-200 px-3 py-1.5 rounded-lg hover:bg-gray-50"
+          >
+            Télécharger SVG
+          </a>
+          <button
+            onClick={() => window.print()}
+            className="bg-blue-600 text-white px-4 py-2 rounded-xl text-sm font-medium hover:bg-blue-700"
+          >
+            Imprimer
+          </button>
+        </div>
+      </div>
+
+      <div className="print-page bg-white border border-gray-200 rounded-2xl p-8 mx-auto max-w-md text-center">
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">{title}</h2>
+        <p className="text-sm text-gray-600">{formatDateRange(startDate, endDate)}</p>
+        {location && <p className="text-sm text-gray-500 mt-1">📍 {location}</p>}
+
+        <div className="my-6 flex items-center justify-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={pngUrl}
+            alt={`QR code vers ${publicUrl}`}
+            className="w-72 h-72"
+          />
+        </div>
+
+        <p className="text-base font-medium text-gray-700 mb-1">Scanner pour s&apos;inscrire</p>
+        <p className="text-xs text-gray-500 break-all">{publicUrl}</p>
+      </div>
+
+      <style>{`
+        @media print {
+          @page { size: A4; margin: 1.5cm; }
+          body { background: white; }
+          .no-print { display: none !important; }
+          .print-page {
+            border: none !important;
+            box-shadow: none !important;
+            margin: 0 auto !important;
+          }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/components/admin/SendReminderButton.tsx
+++ b/src/components/admin/SendReminderButton.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+
+type Props = {
+  eventId: string
+  hasMessage: boolean
+  volunteerCount: number
+  lastSentAt: string | null
+}
+
+function formatRelative(iso: string): string {
+  const date = new Date(iso)
+  const diffMs = Date.now() - date.getTime()
+  const minutes = Math.floor(diffMs / 60_000)
+  if (minutes < 1) return "à l'instant"
+  if (minutes < 60) return `il y a ${minutes} min`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `il y a ${hours} h`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `il y a ${days} j`
+  return date.toLocaleDateString("fr-FR")
+}
+
+export default function SendReminderButton({ eventId, hasMessage, volunteerCount, lastSentAt }: Props) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<string | null>(null)
+  const [, startTransition] = useTransition()
+
+  const disabled = volunteerCount === 0
+
+  async function send() {
+    setSubmitting(true)
+    setResult(null)
+    const res = await fetch(`/api/admin/events/${eventId}/send-reminder`, { method: "POST" })
+    setSubmitting(false)
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setResult(typeof data?.error === "string" ? data.error : "Erreur lors de l'envoi")
+      return
+    }
+    const data = await res.json()
+    setResult(`${data.sent} rappel${data.sent > 1 ? "s" : ""} envoyé${data.sent > 1 ? "s" : ""}${data.failed ? ` · ${data.failed} échec${data.failed > 1 ? "s" : ""}` : ""}`)
+    startTransition(() => router.refresh())
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        className="bg-orange-600 text-white px-4 py-2 rounded-xl text-sm font-medium hover:bg-orange-700 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        📧 Envoyer le rappel ({volunteerCount} bénévole{volunteerCount > 1 ? "s" : ""})
+      </button>
+      {lastSentAt && (
+        <span className="text-xs text-gray-400">
+          Dernier envoi {formatRelative(lastSentAt)}
+        </span>
+      )}
+
+      {open && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4" onClick={() => setOpen(false)}>
+          <div className="bg-white rounded-2xl p-5 max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+            <h2 className="text-lg font-semibold text-gray-900 mb-3">Envoyer le rappel ?</h2>
+            <p className="text-sm text-gray-600 mb-4">
+              Un email sera envoyé à <strong>{volunteerCount} bénévole{volunteerCount > 1 ? "s" : ""}</strong>.
+              Chacun recevra ses créneaux et le message de rappel configuré dans l&apos;event.
+            </p>
+            {!hasMessage && (
+              <div className="bg-orange-50 border border-orange-200 rounded-lg p-3 text-xs text-orange-800 mb-4">
+                ⚠ Le message de rappel est vide. L&apos;email contiendra uniquement le récap des créneaux.
+                <br />
+                <a href={`/admin/events/${eventId}/edit`} className="underline">Ajouter un message</a>
+              </div>
+            )}
+            {result && (
+              <div className="bg-gray-50 rounded-lg p-3 text-sm text-gray-700 mb-4">{result}</div>
+            )}
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setOpen(false)} className="text-sm px-4 py-2 text-gray-600 hover:text-gray-900">
+                {result ? "Fermer" : "Annuler"}
+              </button>
+              {!result && (
+                <button
+                  onClick={send}
+                  disabled={submitting}
+                  className="bg-orange-600 text-white text-sm px-4 py-2 rounded-xl font-medium hover:bg-orange-700 disabled:opacity-50"
+                >
+                  {submitting ? "Envoi…" : "Envoyer"}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/SuperAdminNav.tsx
+++ b/src/components/admin/SuperAdminNav.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { signOut } from "next-auth/react"
+
+export default function SuperAdminNav({ userName }: { userName: string }) {
+  const pathname = usePathname()
+
+  return (
+    <nav className="bg-purple-50 border-b border-purple-200 px-4">
+      <div className="max-w-5xl mx-auto flex items-center justify-between h-14">
+        <div className="flex items-center gap-6">
+          <Link href="/super-admin/organizations" className="font-semibold text-purple-900 text-sm">
+            ⚙ Super admin
+          </Link>
+          <Link
+            href="/super-admin/organizations"
+            className={`text-sm ${pathname.startsWith("/super-admin/organizations") ? "text-purple-700 font-medium" : "text-purple-500 hover:text-purple-800"}`}
+          >
+            Organisations
+          </Link>
+          <Link href="/admin" className="text-sm text-gray-500 hover:text-gray-800">
+            ↩ Vue admin
+          </Link>
+        </div>
+        <div className="flex items-center gap-4">
+          <span className="text-xs text-purple-500">{userName}</span>
+          <button
+            onClick={() => signOut({ callbackUrl: "/admin/login" })}
+            className="text-xs text-purple-500 hover:text-purple-800"
+          >
+            Déconnexion
+          </button>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/src/components/admin/TeamManager.tsx
+++ b/src/components/admin/TeamManager.tsx
@@ -1,0 +1,211 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+
+type Admin = {
+  id: string
+  email: string
+  name: string
+  role: string
+  isActive: boolean
+}
+
+type Invitation = {
+  id: string
+  email: string
+  daysLeft: number
+  inviterName: string
+}
+
+type Props = {
+  currentUserId: string
+  admins: Admin[]
+  invitations: Invitation[]
+}
+
+export default function TeamManager({ currentUserId, admins, invitations }: Props) {
+  const router = useRouter()
+  const [showInvite, setShowInvite] = useState(false)
+  const [, startTransition] = useTransition()
+
+  function refresh() {
+    startTransition(() => router.refresh())
+  }
+
+  async function deactivate(id: string) {
+    if (!confirm("Désactiver cet administrateur ?")) return
+    const res = await fetch(`/api/admin/team/${id}`, { method: "DELETE" })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      alert(data?.error ?? "Erreur")
+      return
+    }
+    refresh()
+  }
+
+  async function revokeInvite(id: string) {
+    if (!confirm("Révoquer cette invitation ?")) return
+    const res = await fetch(`/api/admin/invitations/${id}`, { method: "DELETE" })
+    if (res.ok) refresh()
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">Équipe administrateurs</h1>
+          <p className="text-sm text-gray-500">{admins.filter((a) => a.isActive).length} actif{admins.filter((a) => a.isActive).length > 1 ? "s" : ""}</p>
+        </div>
+        <button
+          onClick={() => setShowInvite(true)}
+          className="bg-blue-600 text-white px-4 py-2 rounded-xl text-sm font-medium hover:bg-blue-700"
+        >
+          + Inviter un admin
+        </button>
+      </div>
+
+      <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+        <div className="px-4 py-2 text-xs uppercase tracking-wide text-gray-500 bg-gray-50 border-b border-gray-100">
+          Membres actifs
+        </div>
+        <table className="w-full text-sm">
+          <tbody>
+            {admins.map((a) => (
+              <tr key={a.id} className={`border-t border-gray-100 ${!a.isActive ? "opacity-50" : ""}`}>
+                <td className="px-4 py-3">
+                  <div className="font-medium text-gray-900">{a.name}</div>
+                  <div className="text-xs text-gray-500">{a.email}</div>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full">
+                    {a.role}
+                  </span>
+                  {a.id === currentUserId && (
+                    <span className="text-xs text-blue-600 ml-2">(toi)</span>
+                  )}
+                  {!a.isActive && (
+                    <span className="text-xs text-gray-400 ml-2">inactif</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {a.isActive && a.id !== currentUserId && (
+                    <button
+                      onClick={() => deactivate(a.id)}
+                      className="text-xs text-gray-400 hover:text-red-600"
+                    >
+                      Désactiver
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {invitations.length > 0 && (
+        <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+          <div className="px-4 py-2 text-xs uppercase tracking-wide text-gray-500 bg-gray-50 border-b border-gray-100">
+            Invitations en attente
+          </div>
+          <table className="w-full text-sm">
+            <tbody>
+              {invitations.map((i) => (
+                <tr key={i.id} className="border-t border-gray-100">
+                  <td className="px-4 py-3">
+                    <div className="text-sm text-gray-900">{i.email}</div>
+                    <div className="text-xs text-gray-500">invité par {i.inviterName}</div>
+                  </td>
+                  <td className="px-4 py-3 text-xs text-gray-500">
+                    Expire dans {i.daysLeft} jour{i.daysLeft > 1 ? "s" : ""}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => revokeInvite(i.id)}
+                      className="text-xs text-gray-400 hover:text-red-600"
+                    >
+                      Révoquer
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {showInvite && (
+        <InviteModal
+          onClose={() => setShowInvite(false)}
+          onDone={() => {
+            setShowInvite(false)
+            refresh()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function InviteModal({ onClose, onDone }: { onClose: () => void; onDone: () => void }) {
+  const [email, setEmail] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    const res = await fetch("/api/admin/invitations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    })
+    setSubmitting(false)
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setError(typeof data?.error === "string" ? data.error : "Erreur")
+      return
+    }
+    setResult(`Invitation envoyée à ${email}`)
+    setTimeout(onDone, 1200)
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4" onClick={onClose}>
+      <div className="bg-white rounded-2xl p-5 max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Inviter un administrateur</h2>
+        <form onSubmit={submit} className="space-y-3">
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="email@asso.dev"
+            className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          {error && <div className="bg-red-50 border border-red-200 rounded-lg p-2.5 text-sm text-red-700">{error}</div>}
+          {result && <div className="bg-green-50 border border-green-200 rounded-lg p-2.5 text-sm text-green-700">{result}</div>}
+          <p className="text-xs text-gray-500">
+            Un email avec un lien d&apos;activation sera envoyé. Le destinataire choisit son nom et son mot de passe.
+            Lien valable 7 jours.
+          </p>
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className="text-sm px-4 py-2 text-gray-600 hover:text-gray-900">
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !!result}
+              className="bg-blue-600 text-white text-sm px-4 py-2 rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? "Envoi…" : "Envoyer l'invitation"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/__tests__/auth-guard.test.ts
+++ b/src/lib/__tests__/auth-guard.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { NextResponse } from "next/server"
+
+const { authMock } = vi.hoisted(() => ({ authMock: vi.fn() }))
+
+vi.mock("@/auth", () => ({ auth: authMock }))
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    $extends: () => ({ __scoped: true }),
+  },
+}))
+
+import { requireOrgSession, requireSuperAdmin, getOrgContext } from "../auth-guard"
+
+describe("requireOrgSession", () => {
+  beforeEach(() => {
+    authMock.mockReset()
+  })
+
+  it("returns 401 when no session", async () => {
+    authMock.mockResolvedValue(null)
+    const result = await requireOrgSession()
+    expect(result).toBeInstanceOf(NextResponse)
+    expect((result as NextResponse).status).toBe(401)
+  })
+
+  it("returns 403 when user has no organizationId (e.g. super admin)", async () => {
+    authMock.mockResolvedValue({ user: { role: "super_admin", organizationId: null } })
+    const result = await requireOrgSession()
+    expect(result).toBeInstanceOf(NextResponse)
+    expect((result as NextResponse).status).toBe(403)
+  })
+
+  it("returns scoped client when admin has an organizationId", async () => {
+    authMock.mockResolvedValue({ user: { role: "admin", organizationId: "org-A" } })
+    const result = await requireOrgSession()
+    expect(result).not.toBeInstanceOf(NextResponse)
+    if (result instanceof NextResponse) return
+    expect(result.organizationId).toBe("org-A")
+    expect(result.db).toBeDefined()
+  })
+})
+
+describe("requireSuperAdmin", () => {
+  beforeEach(() => {
+    authMock.mockReset()
+  })
+
+  it("returns 401 when no session", async () => {
+    authMock.mockResolvedValue(null)
+    const result = await requireSuperAdmin()
+    expect(result).toBeInstanceOf(NextResponse)
+    expect((result as NextResponse).status).toBe(401)
+  })
+
+  it("returns 403 when user is not super_admin", async () => {
+    authMock.mockResolvedValue({ user: { role: "admin", organizationId: "org-A" } })
+    const result = await requireSuperAdmin()
+    expect(result).toBeInstanceOf(NextResponse)
+    expect((result as NextResponse).status).toBe(403)
+  })
+
+  it("returns the unscoped client when user is super_admin", async () => {
+    authMock.mockResolvedValue({ user: { role: "super_admin", organizationId: null } })
+    const result = await requireSuperAdmin()
+    expect(result).not.toBeInstanceOf(NextResponse)
+    if (result instanceof NextResponse) return
+    expect(result.session).toBeDefined()
+    expect(result.db).toBeDefined()
+  })
+})
+
+describe("getOrgContext (SSR helper)", () => {
+  beforeEach(() => {
+    authMock.mockReset()
+  })
+
+  it("returns null when not authenticated", async () => {
+    authMock.mockResolvedValue(null)
+    const result = await getOrgContext()
+    expect(result).toBeNull()
+  })
+
+  it("returns null when user has no organizationId", async () => {
+    authMock.mockResolvedValue({ user: { role: "super_admin", organizationId: null } })
+    const result = await getOrgContext()
+    expect(result).toBeNull()
+  })
+
+  it("returns scoped client when admin has an organizationId", async () => {
+    authMock.mockResolvedValue({ user: { role: "admin", organizationId: "org-B" } })
+    const result = await getOrgContext()
+    expect(result).not.toBeNull()
+    expect(result?.organizationId).toBe("org-B")
+    expect(result?.db).toBeDefined()
+  })
+})

--- a/src/lib/__tests__/auth-guard.test.ts
+++ b/src/lib/__tests__/auth-guard.test.ts
@@ -5,9 +5,12 @@ const { authMock } = vi.hoisted(() => ({ authMock: vi.fn() }))
 
 vi.mock("@/auth", () => ({ auth: authMock }))
 
+const { firstOrgMock } = vi.hoisted(() => ({ firstOrgMock: vi.fn() }))
+
 vi.mock("../prisma", () => ({
   prisma: {
     $extends: () => ({ __scoped: true }),
+    organization: { findFirst: firstOrgMock },
   },
 }))
 
@@ -74,6 +77,7 @@ describe("requireSuperAdmin", () => {
 describe("getOrgContext (SSR helper)", () => {
   beforeEach(() => {
     authMock.mockReset()
+    firstOrgMock.mockReset()
   })
 
   it("returns null when not authenticated", async () => {
@@ -82,8 +86,23 @@ describe("getOrgContext (SSR helper)", () => {
     expect(result).toBeNull()
   })
 
-  it("returns null when user has no organizationId", async () => {
+  it("returns null when an org admin has no organizationId", async () => {
+    authMock.mockResolvedValue({ user: { role: "admin", organizationId: null } })
+    const result = await getOrgContext()
+    expect(result).toBeNull()
+  })
+
+  it("falls back to the first organization for a super_admin without org", async () => {
     authMock.mockResolvedValue({ user: { role: "super_admin", organizationId: null } })
+    firstOrgMock.mockResolvedValue({ id: "first-org" })
+    const result = await getOrgContext()
+    expect(result).not.toBeNull()
+    expect(result?.organizationId).toBe("first-org")
+  })
+
+  it("returns null for a super_admin if no organization exists yet", async () => {
+    authMock.mockResolvedValue({ user: { role: "super_admin", organizationId: null } })
+    firstOrgMock.mockResolvedValue(null)
     const result = await getOrgContext()
     expect(result).toBeNull()
   })

--- a/src/lib/__tests__/csv-import.test.ts
+++ b/src/lib/__tests__/csv-import.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest"
+import { parseCsv } from "../csv-import"
+
+describe("parseCsv — header detection", () => {
+  it("detects standard French headers", () => {
+    const csv = "prenom,nom,email,telephone,tags\nAlice,Martin,alice@x.com,+41 79 1,bar"
+    const result = parseCsv(csv)
+    expect(result.detectedColumns.firstName).toBe("prenom")
+    expect(result.detectedColumns.lastName).toBe("nom")
+    expect(result.detectedColumns.email).toBe("email")
+    expect(result.detectedColumns.phone).toBe("telephone")
+    expect(result.detectedColumns.tags).toBe("tags")
+  })
+
+  it("detects accented and capitalised variants", () => {
+    const csv = "Prénom,Nom de famille,E-mail,Téléphone,Tags\nBob,Dupont,bob@x.com,,musicien"
+    const result = parseCsv(csv)
+    expect(result.detectedColumns.firstName).toBe("Prénom")
+    expect(result.detectedColumns.lastName).toBe("Nom de famille")
+    expect(result.detectedColumns.email).toBe("E-mail")
+    expect(result.detectedColumns.phone).toBe("Téléphone")
+  })
+
+  it("detects English headers (firstName, lastName)", () => {
+    const csv = "firstName,lastName,email\nAlice,M,a@x.com"
+    const result = parseCsv(csv)
+    expect(result.detectedColumns.firstName).toBe("firstName")
+    expect(result.detectedColumns.lastName).toBe("lastName")
+  })
+})
+
+describe("parseCsv — row validation", () => {
+  it("parses a clean CSV with all fields", () => {
+    const csv = `prenom,nom,email,telephone,tags
+Alice,Martin,alice@x.com,+41 79 123 45 67,"parent CM2,bar"
+Bob,Dupont,bob@x.com,,musicien`
+    const result = parseCsv(csv)
+    expect(result.errors).toHaveLength(0)
+    expect(result.rows).toHaveLength(2)
+    expect(result.rows[0]).toEqual({
+      firstName: "Alice",
+      lastName: "Martin",
+      email: "alice@x.com",
+      phone: "+41 79 123 45 67",
+      tags: ["parent CM2", "bar"],
+    })
+    expect(result.rows[1]).toEqual({
+      firstName: "Bob",
+      lastName: "Dupont",
+      email: "bob@x.com",
+      phone: undefined,
+      tags: ["musicien"],
+    })
+  })
+
+  it("supports semicolon and pipe separators in tags column", () => {
+    const csv = `prenom,nom,tags\nAlice,M,"a;b|c,d"`
+    const result = parseCsv(csv)
+    expect(result.rows[0]?.tags).toEqual(["a", "b", "c", "d"])
+  })
+
+  it("reports an error for rows missing the first name", () => {
+    const csv = "prenom,nom\n,Martin"
+    const result = parseCsv(csv)
+    expect(result.rows).toHaveLength(0)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].reason).toMatch(/Pr[ée]nom/i)
+    expect(result.errors[0].line).toBe(2)
+  })
+
+  it("reports an error for rows missing the last name", () => {
+    const csv = "prenom,nom\nAlice,"
+    const result = parseCsv(csv)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].reason).toMatch(/Nom/i)
+  })
+
+  it("reports an error for invalid emails", () => {
+    const csv = "prenom,nom,email\nAlice,M,not-an-email"
+    const result = parseCsv(csv)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].reason).toMatch(/Email invalide/i)
+  })
+
+  it("returns empty preview for an empty file", () => {
+    const result = parseCsv("")
+    expect(result.rows).toHaveLength(0)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  it("ignores rows with neither prenom nor nom but reports them as errors", () => {
+    const csv = "prenom,nom\n,\nAlice,Martin"
+    const result = parseCsv(csv)
+    expect(result.rows).toHaveLength(1)
+    expect(result.errors).toHaveLength(1)
+  })
+})

--- a/src/lib/__tests__/env.test.ts
+++ b/src/lib/__tests__/env.test.ts
@@ -3,8 +3,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 const VALID_ENV = {
   DATABASE_URL: "postgresql://user:pass@localhost:5432/db",
   AUTH_SECRET: "a".repeat(32),
-  ADMIN_EMAIL: "admin@example.com",
-  ADMIN_PASSWORD: "secret",
   NEXT_PUBLIC_APP_URL: "http://localhost:3000",
 }
 
@@ -20,53 +18,52 @@ describe("env validation", () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllEnvs()
   })
 
   it("parse sans erreur avec toutes les vars valides", async () => {
     vi.stubEnv("DATABASE_URL", VALID_ENV.DATABASE_URL)
     vi.stubEnv("AUTH_SECRET", VALID_ENV.AUTH_SECRET)
-    vi.stubEnv("ADMIN_EMAIL", VALID_ENV.ADMIN_EMAIL)
-    vi.stubEnv("ADMIN_PASSWORD", VALID_ENV.ADMIN_PASSWORD)
 
     await import("../env")
 
     expect(exitSpy).not.toHaveBeenCalled()
-    vi.unstubAllEnvs()
   })
 
   it("appelle process.exit(1) si DATABASE_URL est absente", async () => {
     vi.stubEnv("DATABASE_URL", "")
     vi.stubEnv("AUTH_SECRET", VALID_ENV.AUTH_SECRET)
-    vi.stubEnv("ADMIN_EMAIL", VALID_ENV.ADMIN_EMAIL)
-    vi.stubEnv("ADMIN_PASSWORD", VALID_ENV.ADMIN_PASSWORD)
 
     await import("../env")
 
     expect(exitSpy).toHaveBeenCalledWith(1)
-    vi.unstubAllEnvs()
   })
 
   it("appelle process.exit(1) si AUTH_SECRET est trop court", async () => {
     vi.stubEnv("DATABASE_URL", VALID_ENV.DATABASE_URL)
     vi.stubEnv("AUTH_SECRET", "court")
-    vi.stubEnv("ADMIN_EMAIL", VALID_ENV.ADMIN_EMAIL)
-    vi.stubEnv("ADMIN_PASSWORD", VALID_ENV.ADMIN_PASSWORD)
 
     await import("../env")
 
     expect(exitSpy).toHaveBeenCalledWith(1)
-    vi.unstubAllEnvs()
   })
 
   it("affiche un message d'erreur explicite en cas d'échec", async () => {
     vi.stubEnv("DATABASE_URL", "")
     vi.stubEnv("AUTH_SECRET", VALID_ENV.AUTH_SECRET)
-    vi.stubEnv("ADMIN_EMAIL", VALID_ENV.ADMIN_EMAIL)
-    vi.stubEnv("ADMIN_PASSWORD", VALID_ENV.ADMIN_PASSWORD)
 
     await import("../env")
 
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("DATABASE_URL"))
-    vi.unstubAllEnvs()
+  })
+
+  it("ne valide pas ADMIN_EMAIL / ADMIN_PASSWORD (utilisées seulement par le seed)", async () => {
+    vi.stubEnv("DATABASE_URL", VALID_ENV.DATABASE_URL)
+    vi.stubEnv("AUTH_SECRET", VALID_ENV.AUTH_SECRET)
+    // ADMIN_EMAIL / ADMIN_PASSWORD volontairement absents
+
+    await import("../env")
+
+    expect(exitSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/__tests__/notifications.test.ts
+++ b/src/lib/__tests__/notifications.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest"
+import { render } from "../notifications/templates"
+
+describe("notification templates — render()", () => {
+  it("renders a registration confirmation with editToken in the link", () => {
+    const out = render({
+      kind: "registration_confirmation",
+      recipient: { email: "alice@example.com", name: "Alice" },
+      data: {
+        volunteerName: "Alice",
+        eventTitle: "Concert d'été",
+        shifts: [{ label: "Bar", date: "samedi 14 juin", startTime: "14:00", endTime: "18:00" }],
+        editToken: "tok-abc",
+      },
+    })
+    expect(out.subject).toContain("Concert d'été")
+    expect(out.html).toContain("/my/tok-abc")
+    expect(out.text).toContain("/my/tok-abc")
+    expect(out.text).toContain("Alice")
+  })
+
+  it("escapes HTML special chars in volunteer name", () => {
+    const out = render({
+      kind: "registration_confirmation",
+      recipient: { email: "x@y.com", name: "X" },
+      data: {
+        volunteerName: "<script>alert(1)</script>",
+        eventTitle: "Test",
+        shifts: [],
+        editToken: "tok",
+      },
+    })
+    expect(out.html).not.toContain("<script>alert(1)</script>")
+    expect(out.html).toContain("&lt;script&gt;")
+  })
+
+  it("escapes HTML in member invite custom message", () => {
+    const out = render({
+      kind: "member_invite",
+      recipient: { email: "m@x.com", name: "M" },
+      data: {
+        memberName: "Marie",
+        organizationName: "École",
+        eventTitle: "Spectacle",
+        eventDate: "14 juin",
+        eventLocation: "Salle A",
+        eventSlug: "spectacle",
+        message: '<img src=x onerror="alert(1)">',
+        token: "t1",
+      },
+    })
+    expect(out.html).not.toContain('onerror="alert')
+    expect(out.html).toContain("&lt;img")
+  })
+
+  it("renders reminder J-2 with shift details", () => {
+    const out = render({
+      kind: "reminder_j2",
+      recipient: { email: "a@x.com" },
+      data: {
+        volunteerName: "Alice",
+        eventTitle: "Concert",
+        organizationName: "Asso",
+        shiftLabel: "Buvette",
+        shiftRoleName: "Bar",
+        shiftDate: "samedi 14 juin",
+        shiftStart: "14:00",
+        shiftEnd: "18:00",
+        shiftLocation: "Salle des fêtes",
+        editToken: "tok",
+      },
+    })
+    expect(out.subject).toContain("J-2")
+    expect(out.text).toContain("Salle des fêtes")
+    expect(out.text).toContain("14:00")
+    expect(out.text).toContain("/my/tok")
+  })
+
+  it("renders reminder day-of with hoursUntil", () => {
+    const out = render({
+      kind: "reminder_dd",
+      recipient: { email: "a@x.com" },
+      data: {
+        volunteerName: "Alice",
+        eventTitle: "Concert",
+        organizationName: "Asso",
+        shiftLabel: "Buvette",
+        shiftRoleName: "Bar",
+        shiftDate: "samedi 14 juin",
+        shiftStart: "14:00",
+        shiftEnd: "18:00",
+        shiftLocation: null,
+        editToken: "tok",
+        hoursUntil: 3,
+      },
+    })
+    expect(out.subject).toContain("aujourd'hui")
+    expect(out.html).toContain("dans 3h")
+  })
+
+  it("renders manual reminder with custom message + multiple shifts", () => {
+    const out = render({
+      kind: "manual_reminder",
+      recipient: { email: "v@x.com" },
+      data: {
+        volunteerName: "Bob",
+        organizationName: "Asso",
+        eventTitle: "Concert",
+        customMessage: "Tenue noire SVP, RDV entrée artistes.",
+        shifts: [
+          { label: "Bar", date: "samedi 14", startTime: "14:00", endTime: "18:00", roleName: "Bar" },
+          { label: "Démontage", date: "samedi 14", startTime: "22:00", endTime: "00:00", roleName: "Démontage" },
+        ],
+        editToken: "tok",
+      },
+    })
+    expect(out.text).toContain("Tenue noire")
+    expect(out.text).toContain("Bar")
+    expect(out.text).toContain("Démontage")
+    expect(out.subject).toContain("Rappel")
+  })
+
+  it("renders shift modified with old vs new schedule", () => {
+    const out = render({
+      kind: "shift_modified",
+      recipient: { email: "v@x.com" },
+      data: {
+        volunteerName: "Bob",
+        eventTitle: "Concert",
+        shiftLabel: "Bar",
+        oldDate: "samedi 14",
+        newDate: "dimanche 15",
+        oldStart: "14:00",
+        newStart: "15:00",
+        oldEnd: "18:00",
+        newEnd: "19:00",
+        editToken: "tok",
+      },
+    })
+    expect(out.html).toContain("samedi 14")
+    expect(out.html).toContain("dimanche 15")
+    expect(out.html).toContain("15:00")
+    expect(out.subject).toContain("Changement")
+  })
+
+  it("renders shift cancelled with link back to event", () => {
+    const out = render({
+      kind: "shift_cancelled",
+      recipient: { email: "v@x.com" },
+      data: {
+        volunteerName: "Bob",
+        eventTitle: "Concert",
+        eventSlug: "concert-2026",
+        shiftLabel: "Bar",
+        shiftDate: "samedi 14",
+      },
+    })
+    expect(out.html).toContain("/events/concert-2026")
+    expect(out.subject).toContain("annulé")
+  })
+})

--- a/src/lib/__tests__/prisma-org.test.ts
+++ b/src/lib/__tests__/prisma-org.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Capture the extension config so the tests can drive each callback
+// directly without spinning up Prisma.
+const lastExtendConfig: { current: unknown } = { current: null }
+
+vi.mock("../prisma", () => {
+  return {
+    prisma: {
+      $extends(config: unknown) {
+        lastExtendConfig.current = config
+        return { __scoped: true, config }
+      },
+    },
+  }
+})
+
+import { getOrgClient } from "../prisma-org"
+
+type ExtensionConfig = {
+  name: string
+  query: Record<
+    string,
+    Record<
+      string,
+      (input: { args: Record<string, unknown>; query: (a: unknown) => unknown }) => Promise<unknown>
+    >
+  >
+}
+
+function getConfig(): ExtensionConfig {
+  if (!lastExtendConfig.current) throw new Error("extension not configured")
+  return lastExtendConfig.current as ExtensionConfig
+}
+
+describe("getOrgClient", () => {
+  beforeEach(() => {
+    lastExtendConfig.current = null
+  })
+
+  it("registers an extension named 'org-scoped' for all tenant models", () => {
+    getOrgClient("org-A")
+    const cfg = getConfig()
+    expect(cfg.name).toBe("org-scoped")
+    expect(cfg.query.event.findMany).toBeTypeOf("function")
+    expect(cfg.query.event.findFirst).toBeTypeOf("function")
+    expect(cfg.query.event.create).toBeTypeOf("function")
+    expect(cfg.query.member.findMany).toBeTypeOf("function")
+    expect(cfg.query.member.create).toBeTypeOf("function")
+    expect(cfg.query.shift.findMany).toBeTypeOf("function")
+    expect(cfg.query.registration.findMany).toBeTypeOf("function")
+  })
+
+  describe("event scoping", () => {
+    it("injects organizationId into event.findMany where clause", async () => {
+      getOrgClient("org-A")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue([])
+      const args = { where: { publicStatus: "published" } }
+
+      await cfg.query.event.findMany({ args, query })
+
+      expect(query).toHaveBeenCalledWith(args)
+      expect(args.where).toEqual({ publicStatus: "published", organizationId: "org-A" })
+    })
+
+    it("injects organizationId into event.findFirst where clause", async () => {
+      getOrgClient("org-B")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue(null)
+      const args = { where: { id: "evt-from-other-org" } }
+
+      await cfg.query.event.findFirst({ args, query })
+
+      expect(args.where).toEqual({ id: "evt-from-other-org", organizationId: "org-B" })
+    })
+
+    it("forces event.create to use the calling org's id (overrides any caller-provided value)", async () => {
+      getOrgClient("org-A")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue({})
+      const args = { data: { title: "Festival", organizationId: "ATTACKER" } }
+
+      await cfg.query.event.create({ args, query })
+
+      expect((args.data as { organizationId: string }).organizationId).toBe("org-A")
+    })
+
+    it("event.count is also scoped", async () => {
+      getOrgClient("org-A")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue(0)
+      const args = {}
+
+      await cfg.query.event.count({ args, query })
+
+      expect((args as { where: unknown }).where).toEqual({ organizationId: "org-A" })
+    })
+  })
+
+  describe("member scoping", () => {
+    it("injects organizationId into member.findMany where clause", async () => {
+      getOrgClient("org-A")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue([])
+      const args = { where: { active: true } }
+
+      await cfg.query.member.findMany({ args, query })
+
+      expect(args.where).toEqual({ active: true, organizationId: "org-A" })
+    })
+
+    it("forces member.create to use the calling org's id", async () => {
+      getOrgClient("org-A")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue({})
+      const args = { data: { firstName: "Alice", lastName: "M.", organizationId: "ATTACKER" } }
+
+      await cfg.query.member.create({ args, query })
+
+      expect((args.data as { organizationId: string }).organizationId).toBe("org-A")
+    })
+  })
+
+  describe("shift scoping (via parent event)", () => {
+    it("injects event.organizationId filter into shift.findMany", async () => {
+      getOrgClient("org-A")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue([])
+      const args = { where: { status: "open" } }
+
+      await cfg.query.shift.findMany({ args, query })
+
+      expect(args.where).toEqual({
+        status: "open",
+        event: { organizationId: "org-A" },
+      })
+    })
+
+    it("preserves existing event filters when scoping shift queries", async () => {
+      getOrgClient("org-A")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue([])
+      const args = { where: { event: { publicStatus: "published" } } }
+
+      await cfg.query.shift.findFirst({ args, query })
+
+      expect(args.where).toEqual({
+        event: { publicStatus: "published", organizationId: "org-A" },
+      })
+    })
+  })
+
+  describe("registration scoping (via parent event)", () => {
+    it("injects event.organizationId filter into registration.findMany", async () => {
+      getOrgClient("org-A")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue([])
+      const args = { where: { status: "active" } }
+
+      await cfg.query.registration.findMany({ args, query })
+
+      expect(args.where).toEqual({
+        status: "active",
+        event: { organizationId: "org-A" },
+      })
+    })
+  })
+
+  describe("cross-tenant isolation", () => {
+    it("two clients with different orgs scope to their own org id", async () => {
+      const clientA = getOrgClient("org-A")
+      const cfgA = getConfig()
+      const query = vi.fn().mockResolvedValue([])
+      const argsA = { where: {} }
+      await cfgA.query.event.findMany({ args: argsA, query })
+      expect(argsA.where).toEqual({ organizationId: "org-A" })
+
+      // Different org → fresh extension config
+      const clientB = getOrgClient("org-B")
+      const cfgB = getConfig()
+      const argsB = { where: {} }
+      await cfgB.query.event.findMany({ args: argsB, query })
+      expect(argsB.where).toEqual({ organizationId: "org-B" })
+
+      // Sanity: both produced distinct extended clients
+      expect(clientA).not.toBe(clientB)
+    })
+  })
+})

--- a/src/lib/__tests__/prisma-org.test.ts
+++ b/src/lib/__tests__/prisma-org.test.ts
@@ -167,6 +167,34 @@ describe("getOrgClient", () => {
     })
   })
 
+  describe("memberInvite scoping (via parent event)", () => {
+    it("injects event.organizationId filter into memberInvite.findMany", async () => {
+      getOrgClient("org-A")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue([])
+      const args = { where: {} }
+
+      await cfg.query.memberInvite.findMany({ args, query })
+
+      expect(args.where).toEqual({
+        event: { organizationId: "org-A" },
+      })
+    })
+
+    it("preserves existing event filter when scoping memberInvite queries", async () => {
+      getOrgClient("org-A")
+      const cfg = getConfig()
+      const query = vi.fn().mockResolvedValue(null)
+      const args = { where: { event: { id: "evt-1" } } }
+
+      await cfg.query.memberInvite.findFirst({ args, query })
+
+      expect(args.where).toEqual({
+        event: { id: "evt-1", organizationId: "org-A" },
+      })
+    })
+  })
+
   describe("cross-tenant isolation", () => {
     it("two clients with different orgs scope to their own org id", async () => {
       const clientA = getOrgClient("org-A")

--- a/src/lib/auth-guard.ts
+++ b/src/lib/auth-guard.ts
@@ -57,13 +57,30 @@ export async function requireSuperAdmin() {
 
 /**
  * SSR variant for Server Components. Returns the org-scoped client or
- * `null` when the caller is not attached to an organization. Pages should
- * `redirect()` or call `notFound()` based on the result.
+ * `null` when the caller is not authenticated. Pages should `redirect()`
+ * or call `notFound()` based on the result.
+ *
+ * Super admins (no organizationId in their JWT) are silently routed to
+ * the first organization in the database so they can use the regular
+ * /admin/* pages without bouncing back to the login page. A proper
+ * /super-admin UI with an org switcher is on the roadmap (issue #35);
+ * until then this acts as the impersonation default.
  */
 export async function getOrgContext() {
   const session = await auth()
-  const organizationId = session?.user?.organizationId
-  if (!session?.user || !organizationId) return null
+  if (!session?.user) return null
+
+  let organizationId = session.user.organizationId
+  if (!organizationId && session.user.role === "super_admin") {
+    const fallback = await prisma.organization.findFirst({
+      orderBy: { createdAt: "asc" },
+      select: { id: true },
+    })
+    if (!fallback) return null
+    organizationId = fallback.id
+  }
+  if (!organizationId) return null
+
   return {
     session,
     organizationId,

--- a/src/lib/auth-guard.ts
+++ b/src/lib/auth-guard.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server"
+import { auth } from "@/auth"
+import { getOrgClient } from "./prisma-org"
+import { prisma } from "./prisma"
+
+/**
+ * Sentinel error returned by the route helpers below. Routes propagate
+ * it directly when present.
+ */
+type GuardError = NextResponse
+
+function unauthorized(): GuardError {
+  return NextResponse.json({ error: "Non autorisé" }, { status: 401 })
+}
+
+function forbidden(): GuardError {
+  return NextResponse.json({ error: "Accès refusé" }, { status: 403 })
+}
+
+/**
+ * Ensures the caller is an authenticated admin attached to an organization.
+ * Returns the session, the organization id and a Prisma client that
+ * automatically scopes reads to the caller's organization.
+ *
+ * Use in any /api/admin/** route:
+ *
+ *   const guard = await requireOrgSession()
+ *   if (guard instanceof NextResponse) return guard
+ *   const { db, organizationId } = guard
+ */
+export async function requireOrgSession() {
+  const session = await auth()
+  if (!session?.user) return unauthorized()
+  const organizationId = session.user.organizationId
+  if (!organizationId) {
+    // Super admins must use the dedicated super-admin routes; refuse to
+    // operate without an org context to avoid accidental cross-tenant writes.
+    return forbidden()
+  }
+  return {
+    session,
+    organizationId,
+    db: getOrgClient(organizationId),
+  }
+}
+
+/**
+ * Ensures the caller is the platform super admin. Returns the unscoped
+ * Prisma client.
+ */
+export async function requireSuperAdmin() {
+  const session = await auth()
+  if (!session?.user) return unauthorized()
+  if (session.user.role !== "super_admin") return forbidden()
+  return { session, db: prisma }
+}
+
+/**
+ * SSR variant for Server Components. Returns the org-scoped client or
+ * `null` when the caller is not attached to an organization. Pages should
+ * `redirect()` or call `notFound()` based on the result.
+ */
+export async function getOrgContext() {
+  const session = await auth()
+  const organizationId = session?.user?.organizationId
+  if (!session?.user || !organizationId) return null
+  return {
+    session,
+    organizationId,
+    db: getOrgClient(organizationId),
+  }
+}

--- a/src/lib/csv-import.ts
+++ b/src/lib/csv-import.ts
@@ -1,0 +1,161 @@
+import { parse } from "csv-parse/sync"
+import ExcelJS from "exceljs"
+
+export type ParsedMemberRow = {
+  firstName: string
+  lastName: string
+  email?: string
+  phone?: string
+  tags?: string[]
+}
+
+export type ImportError = { line: number; reason: string }
+export type ImportPreview = {
+  rows: ParsedMemberRow[]
+  errors: ImportError[]
+  detectedColumns: Record<string, string | null> // canonical -> source header
+}
+
+const HEADER_ALIASES: Record<keyof ParsedMemberRow, string[]> = {
+  firstName: ["firstname", "first_name", "first name", "prenom", "prénom", "first"],
+  lastName: ["lastname", "last_name", "last name", "nom", "famille", "last", "name", "nom de famille"],
+  email: ["email", "e-mail", "mail", "courriel", "adresse email", "adresse mail"],
+  phone: ["phone", "telephone", "téléphone", "tel", "mobile", "portable", "numero", "numéro"],
+  tags: ["tags", "tag", "labels", "label", "groupes", "categories", "catégories"],
+}
+
+function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[\s_-]+/g, " ")
+    .trim()
+}
+
+function detectColumns(headers: string[]): Record<string, string | null> {
+  const detected: Record<string, string | null> = {
+    firstName: null,
+    lastName: null,
+    email: null,
+    phone: null,
+    tags: null,
+  }
+  const normalizedHeaders = headers.map((h) => normalize(h))
+
+  for (const [canonical, aliases] of Object.entries(HEADER_ALIASES)) {
+    for (let i = 0; i < normalizedHeaders.length; i++) {
+      if (aliases.some((a) => normalize(a) === normalizedHeaders[i])) {
+        detected[canonical] = headers[i]
+        break
+      }
+    }
+  }
+  return detected
+}
+
+function parseTagsValue(value: string): string[] {
+  if (!value) return []
+  return value
+    .split(/[,;|]/)
+    .map((t) => t.trim())
+    .filter(Boolean)
+}
+
+function rowToMember(
+  row: Record<string, string>,
+  detected: Record<string, string | null>,
+  lineNumber: number,
+): { ok: true; member: ParsedMemberRow } | { ok: false; error: ImportError } {
+  const get = (key: string) => {
+    const sourceHeader = detected[key]
+    return sourceHeader ? (row[sourceHeader] ?? "").toString().trim() : ""
+  }
+
+  const firstName = get("firstName")
+  const lastName = get("lastName")
+
+  if (!firstName && !lastName) {
+    return { ok: false, error: { line: lineNumber, reason: "Prénom et nom manquants" } }
+  }
+  if (!firstName) {
+    return { ok: false, error: { line: lineNumber, reason: "Prénom manquant" } }
+  }
+  if (!lastName) {
+    return { ok: false, error: { line: lineNumber, reason: "Nom manquant" } }
+  }
+
+  const email = get("email") || undefined
+  const phone = get("phone") || undefined
+  const tags = parseTagsValue(get("tags"))
+
+  if (email && !email.includes("@")) {
+    return { ok: false, error: { line: lineNumber, reason: `Email invalide : ${email}` } }
+  }
+
+  return {
+    ok: true,
+    member: {
+      firstName,
+      lastName,
+      email,
+      phone,
+      tags: tags.length > 0 ? tags : undefined,
+    },
+  }
+}
+
+export function parseCsv(content: string | Buffer): ImportPreview {
+  const records = parse(content, {
+    columns: true,
+    skip_empty_lines: true,
+    trim: true,
+  }) as Record<string, string>[]
+
+  if (records.length === 0) {
+    return { rows: [], errors: [], detectedColumns: {} }
+  }
+
+  const detected = detectColumns(Object.keys(records[0]))
+  const rows: ParsedMemberRow[] = []
+  const errors: ImportError[] = []
+
+  records.forEach((row, idx) => {
+    const result = rowToMember(row, detected, idx + 2) // +2: header + 1-indexed
+    if (result.ok) rows.push(result.member)
+    else errors.push(result.error)
+  })
+
+  return { rows, errors, detectedColumns: detected }
+}
+
+export async function parseXlsx(buffer: Buffer): Promise<ImportPreview> {
+  const wb = new ExcelJS.Workbook()
+  await wb.xlsx.load(buffer as unknown as ArrayBuffer)
+  const ws = wb.worksheets[0]
+  if (!ws) return { rows: [], errors: [], detectedColumns: {} }
+
+  const headers: string[] = []
+  ws.getRow(1).eachCell({ includeEmpty: false }, (cell) => {
+    headers.push(String(cell.value ?? ""))
+  })
+  if (headers.length === 0) return { rows: [], errors: [], detectedColumns: {} }
+
+  const detected = detectColumns(headers)
+  const rows: ParsedMemberRow[] = []
+  const errors: ImportError[] = []
+
+  ws.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+    if (rowNumber === 1) return // skip header
+    const data: Record<string, string> = {}
+    headers.forEach((h, i) => {
+      const cell = row.getCell(i + 1)
+      data[h] = cell.value == null ? "" : String(cell.value)
+    })
+    const result = rowToMember(data, detected, rowNumber)
+    if (result.ok) rows.push(result.member)
+    else errors.push(result.error)
+  })
+
+  return { rows, errors, detectedColumns: detected }
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -60,6 +60,64 @@ export async function sendConfirmationEmail(data: RegistrationEmailData) {
   })
 }
 
+type MemberInviteEmailData = {
+  to: string
+  memberName: string
+  organizationName: string
+  eventTitle: string
+  eventDate: string
+  eventLocation: string | null
+  eventSlug: string
+  message: string | null
+  token: string
+}
+
+export async function sendMemberInvite(data: MemberInviteEmailData) {
+  const inviteUrl = `${appUrl}/events/${data.eventSlug}?token=${data.token}`
+  const from = process.env.EMAIL_FROM ?? "no-reply@example.com"
+
+  const html = `
+    <div style="font-family:sans-serif;max-width:520px;margin:0 auto;color:#111">
+      <h2>Bonjour ${data.memberName},</h2>
+      <p>${data.organizationName} a besoin de toi pour <strong>${data.eventTitle}</strong>.</p>
+      ${data.message ? `<p style="background:#f3f4f6;padding:12px;border-radius:8px;margin:16px 0">${escapeHtml(data.message)}</p>` : ""}
+      <p>
+        📅 ${data.eventDate}
+        ${data.eventLocation ? `<br>📍 ${data.eventLocation}` : ""}
+      </p>
+      <p style="margin-top:1.5em">
+        <a href="${inviteUrl}" style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;display:inline-block">
+          Voir les missions et m'inscrire
+        </a>
+      </p>
+      <p style="color:#888;font-size:0.85em;margin-top:2em">Si tu ne peux pas, ignore cet email. Merci !</p>
+    </div>
+  `
+
+  const transport = createTransport()
+  if (!transport) {
+    console.log("[EMAIL - pas de SMTP configuré]")
+    console.log(`To: ${data.to} | Sujet: [${data.organizationName}] On a besoin de toi pour ${data.eventTitle}`)
+    console.log(`Lien : ${inviteUrl}`)
+    return
+  }
+
+  await transport.sendMail({
+    from,
+    to: data.to,
+    subject: `[${data.organizationName}] On a besoin de toi pour ${data.eventTitle}`,
+    html,
+  })
+}
+
+function escapeHtml(s: string) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
 export async function sendAdminNotification(data: {
   eventTitle: string
   volunteerName: string

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,19 +1,10 @@
-import nodemailer from "nodemailer"
+/**
+ * Thin wrappers kept for backwards compatibility with existing call
+ * sites. New code should call `sendNotification` from `./notifications`
+ * directly.
+ */
 
-const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"
-
-function createTransport() {
-  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD, SMTP_SECURE } = process.env
-
-  if (!SMTP_HOST || !SMTP_USER || !SMTP_PASSWORD) return null
-
-  return nodemailer.createTransport({
-    host: SMTP_HOST,
-    port: Number(SMTP_PORT ?? 587),
-    secure: SMTP_SECURE === "true",
-    auth: { user: SMTP_USER, pass: SMTP_PASSWORD },
-  })
-}
+import { sendNotification } from "./notifications"
 
 type RegistrationEmailData = {
   to: string
@@ -24,39 +15,15 @@ type RegistrationEmailData = {
 }
 
 export async function sendConfirmationEmail(data: RegistrationEmailData) {
-  const editUrl = `${appUrl}/my/${data.editToken}`
-  const from = process.env.EMAIL_FROM ?? "no-reply@example.com"
-
-  const html = `
-    <div style="font-family:sans-serif;max-width:520px;margin:0 auto;color:#111">
-      <h2>Merci pour votre inscription, ${data.volunteerName} !</h2>
-      <p>Vous êtes inscrit(e) aux créneaux suivants pour <strong>${data.eventTitle}</strong> :</p>
-      <ul style="padding-left:1.2em;line-height:1.8">
-        ${data.shifts.map((s) => `<li><strong>${s.label}</strong> — ${s.date} de ${s.startTime} à ${s.endTime}</li>`).join("")}
-      </ul>
-      <p style="margin-top:1.5em">
-        <a href="${editUrl}" style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;display:inline-block">
-          Voir / annuler mes inscriptions
-        </a>
-      </p>
-      <p style="color:#888;font-size:0.85em;margin-top:2em">Merci pour votre aide précieuse !</p>
-    </div>
-  `
-
-  const transport = createTransport()
-
-  if (!transport) {
-    console.log("[EMAIL - pas de SMTP configuré]")
-    console.log(`To: ${data.to} | Sujet: Confirmation — ${data.eventTitle}`)
-    console.log(`Lien d'édition : ${editUrl}`)
-    return
-  }
-
-  await transport.sendMail({
-    from,
-    to: data.to,
-    subject: `Confirmation d'inscription — ${data.eventTitle}`,
-    html,
+  await sendNotification({
+    kind: "registration_confirmation",
+    recipient: { email: data.to, name: data.volunteerName },
+    data: {
+      volunteerName: data.volunteerName,
+      eventTitle: data.eventTitle,
+      shifts: data.shifts,
+      editToken: data.editToken,
+    },
   })
 }
 
@@ -73,49 +40,20 @@ type MemberInviteEmailData = {
 }
 
 export async function sendMemberInvite(data: MemberInviteEmailData) {
-  const inviteUrl = `${appUrl}/events/${data.eventSlug}?token=${data.token}`
-  const from = process.env.EMAIL_FROM ?? "no-reply@example.com"
-
-  const html = `
-    <div style="font-family:sans-serif;max-width:520px;margin:0 auto;color:#111">
-      <h2>Bonjour ${data.memberName},</h2>
-      <p>${data.organizationName} a besoin de toi pour <strong>${data.eventTitle}</strong>.</p>
-      ${data.message ? `<p style="background:#f3f4f6;padding:12px;border-radius:8px;margin:16px 0">${escapeHtml(data.message)}</p>` : ""}
-      <p>
-        📅 ${data.eventDate}
-        ${data.eventLocation ? `<br>📍 ${data.eventLocation}` : ""}
-      </p>
-      <p style="margin-top:1.5em">
-        <a href="${inviteUrl}" style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;display:inline-block">
-          Voir les missions et m'inscrire
-        </a>
-      </p>
-      <p style="color:#888;font-size:0.85em;margin-top:2em">Si tu ne peux pas, ignore cet email. Merci !</p>
-    </div>
-  `
-
-  const transport = createTransport()
-  if (!transport) {
-    console.log("[EMAIL - pas de SMTP configuré]")
-    console.log(`To: ${data.to} | Sujet: [${data.organizationName}] On a besoin de toi pour ${data.eventTitle}`)
-    console.log(`Lien : ${inviteUrl}`)
-    return
-  }
-
-  await transport.sendMail({
-    from,
-    to: data.to,
-    subject: `[${data.organizationName}] On a besoin de toi pour ${data.eventTitle}`,
-    html,
+  await sendNotification({
+    kind: "member_invite",
+    recipient: { email: data.to, name: data.memberName },
+    data: {
+      memberName: data.memberName,
+      organizationName: data.organizationName,
+      eventTitle: data.eventTitle,
+      eventDate: data.eventDate,
+      eventLocation: data.eventLocation,
+      eventSlug: data.eventSlug,
+      message: data.message,
+      token: data.token,
+    },
   })
-}
-
-function escapeHtml(s: string) {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
 }
 
 export async function sendAdminNotification(data: {
@@ -126,19 +64,9 @@ export async function sendAdminNotification(data: {
 }) {
   const adminEmail = process.env.ADMIN_NOTIFICATION_EMAIL
   if (!adminEmail) return
-
-  const transport = createTransport()
-  if (!transport) return
-
-  const from = process.env.EMAIL_FROM ?? "no-reply@example.com"
-
-  await transport.sendMail({
-    from,
-    to: adminEmail,
-    subject: `Nouvelle inscription — ${data.eventTitle}`,
-    html: `
-      <p><strong>${data.volunteerName}</strong> (${data.volunteerEmail}) vient de s'inscrire à <strong>${data.eventTitle}</strong>.</p>
-      <p>Créneaux : ${data.shifts.map((s) => s.label).join(", ")}</p>
-    `,
+  await sendNotification({
+    kind: "admin_notification",
+    recipient: { email: adminEmail, name: "Admin" },
+    data,
   })
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,10 +1,12 @@
 import { z } from "zod"
 
+// Variables runtime indispensables à l'app. ADMIN_EMAIL / ADMIN_PASSWORD
+// ne sont utilisées que par `prisma/seed.ts` (jamais par l'app), donc
+// elles n'ont pas leur place ici — elles cassaient le build d'image
+// Docker quand elles n'étaient pas fournies en build args.
 const schema = z.object({
   DATABASE_URL: z.string().min(1, "DATABASE_URL est requis"),
   AUTH_SECRET: z.string().min(32, "AUTH_SECRET doit faire au moins 32 caractères"),
-  ADMIN_EMAIL: z.string().email("ADMIN_EMAIL doit être une adresse email valide"),
-  ADMIN_PASSWORD: z.string().min(1, "ADMIN_PASSWORD est requis"),
   NEXT_PUBLIC_APP_URL: z.string().url("NEXT_PUBLIC_APP_URL doit être une URL valide").optional(),
 })
 

--- a/src/lib/notifications/channels/email.ts
+++ b/src/lib/notifications/channels/email.ts
@@ -16,6 +16,11 @@ function createTransport() {
     // Mailpit accepts unauth'd connections; nodemailer needs the auth
     // object to be omitted in that case.
     auth: SMTP_USER && SMTP_PASSWORD ? { user: SMTP_USER, pass: SMTP_PASSWORD } : undefined,
+    // Hard fail fast when SMTP is unreachable so the route doesn't
+    // hang for 30s+ per recipient on a misconfigured port.
+    connectionTimeout: 5_000,
+    greetingTimeout: 5_000,
+    socketTimeout: 10_000,
   })
 }
 

--- a/src/lib/notifications/channels/email.ts
+++ b/src/lib/notifications/channels/email.ts
@@ -1,0 +1,49 @@
+import nodemailer from "nodemailer"
+import type {
+  NotificationChannelImpl,
+  NotificationPayload,
+} from "../types"
+import { render } from "../templates"
+
+function createTransport() {
+  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD, SMTP_SECURE } = process.env
+  if (!SMTP_HOST) return null
+
+  return nodemailer.createTransport({
+    host: SMTP_HOST,
+    port: Number(SMTP_PORT ?? 587),
+    secure: SMTP_SECURE === "true",
+    // Mailpit accepts unauth'd connections; nodemailer needs the auth
+    // object to be omitted in that case.
+    auth: SMTP_USER && SMTP_PASSWORD ? { user: SMTP_USER, pass: SMTP_PASSWORD } : undefined,
+  })
+}
+
+export const emailChannel: NotificationChannelImpl = {
+  name: "email",
+
+  async send(payload: NotificationPayload) {
+    const to = payload.recipient.email
+    if (!to) {
+      return { ok: false as const, reason: "recipient has no email" }
+    }
+
+    const { subject, html, text } = render(payload)
+    const from = process.env.EMAIL_FROM ?? "Bénévoles <no-reply@example.com>"
+    const transport = createTransport()
+
+    if (!transport) {
+      console.log(`[notif:email→${to}] ${subject}`)
+      console.log(`[notif:body]\n${text}\n`)
+      return { ok: true as const }
+    }
+
+    try {
+      await transport.sendMail({ from, to, subject, html, text })
+      return { ok: true as const }
+    } catch (err) {
+      console.error(`[notif:email→${to}] failed:`, err)
+      return { ok: false as const, reason: String(err) }
+    }
+  },
+}

--- a/src/lib/notifications/index.ts
+++ b/src/lib/notifications/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Public API of the notifications layer.
+ *
+ *   await sendNotification({ kind: "registration_confirmation", recipient, data })
+ *
+ * The default channel is email. Future channels (sms, whatsapp) plug
+ * in by adding an entry to `channels` below — no caller change needed.
+ */
+
+import { emailChannel } from "./channels/email"
+import type {
+  NotificationChannel,
+  NotificationChannelImpl,
+  NotificationKind,
+  NotificationPayload,
+} from "./types"
+
+const channels: Record<NotificationChannel, NotificationChannelImpl | null> = {
+  email: emailChannel,
+  sms: null, // TODO: post-MVP
+  whatsapp: null, // TODO: post-MVP
+}
+
+export async function sendNotification(
+  payload: NotificationPayload,
+  channel: NotificationChannel = "email",
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const impl = channels[channel]
+  if (!impl) return { ok: false, reason: `channel ${channel} not implemented` }
+  return impl.send(payload)
+}
+
+export type { NotificationKind, NotificationChannel, NotificationPayload }

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -1,0 +1,381 @@
+/**
+ * Templates for every notification kind. Plain-text + HTML.
+ * Keep them short and transactional — the platform is NOT a mailing tool.
+ */
+
+import type { NotificationPayload } from "./types"
+
+const APP_URL = (process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000").replace(/\/$/, "")
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+function btn(href: string, label: string): string {
+  return `<a href="${href}" style="background:#2563eb;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;display:inline-block;font-weight:600">${label}</a>`
+}
+
+function wrap(inner: string): string {
+  return `<div style="font-family:-apple-system,system-ui,sans-serif;max-width:520px;margin:0 auto;color:#111;line-height:1.5">${inner}</div>`
+}
+
+export type RenderedEmail = {
+  subject: string
+  html: string
+  text: string
+}
+
+export function render(payload: NotificationPayload): RenderedEmail {
+  switch (payload.kind) {
+    case "registration_confirmation":
+      return renderConfirmation(payload)
+    case "member_invite":
+      return renderMemberInvite(payload)
+    case "reminder_j2":
+      return renderReminderJ2(payload)
+    case "reminder_j1":
+      return renderReminderJ1(payload)
+    case "reminder_dd":
+      return renderReminderDd(payload)
+    case "manual_reminder":
+      return renderManualReminder(payload)
+    case "shift_modified":
+      return renderShiftModified(payload)
+    case "shift_cancelled":
+      return renderShiftCancelled(payload)
+    case "registration_cancelled":
+      return renderRegistrationCancelled(payload)
+    case "admin_notification":
+      return renderAdminNotification(payload)
+  }
+}
+
+// ── Inscription confirmée ────────────────────────────────────────────────────
+
+function renderConfirmation(p: NotificationPayload): RenderedEmail {
+  const { volunteerName, eventTitle, shifts, editToken } = p.data as {
+    volunteerName: string
+    eventTitle: string
+    shifts: { label: string; date: string; startTime: string; endTime: string }[]
+    editToken: string
+  }
+  const editUrl = `${APP_URL}/my/${editToken}`
+  const subject = `Confirmation d'inscription — ${eventTitle}`
+
+  const text = [
+    `Merci ${volunteerName} !`,
+    ``,
+    `Vous êtes inscrit·e pour ${eventTitle} :`,
+    ...shifts.map((s) => `  • ${s.label} — ${s.date} de ${s.startTime} à ${s.endTime}`),
+    ``,
+    `Voir / annuler vos inscriptions : ${editUrl}`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Merci pour votre inscription, ${escapeHtml(volunteerName)} !</h2>
+    <p>Vous êtes inscrit·e pour <strong>${escapeHtml(eventTitle)}</strong> :</p>
+    <ul style="padding-left:1.2em">
+      ${shifts.map((s) => `<li><strong>${escapeHtml(s.label)}</strong> — ${escapeHtml(s.date)} de ${escapeHtml(s.startTime)} à ${escapeHtml(s.endTime)}</li>`).join("")}
+    </ul>
+    <p style="margin-top:1.5em">${btn(editUrl, "Voir / annuler mes inscriptions")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Invitation d'un membre ───────────────────────────────────────────────────
+
+function renderMemberInvite(p: NotificationPayload): RenderedEmail {
+  const {
+    memberName,
+    organizationName,
+    eventTitle,
+    eventDate,
+    eventLocation,
+    eventSlug,
+    message,
+    token,
+  } = p.data as {
+    memberName: string
+    organizationName: string
+    eventTitle: string
+    eventDate: string
+    eventLocation: string | null
+    eventSlug: string
+    message: string | null
+    token: string
+  }
+  const inviteUrl = `${APP_URL}/events/${eventSlug}?token=${token}`
+  const subject = `[${organizationName}] On a besoin de toi pour ${eventTitle}`
+
+  const text = [
+    `Bonjour ${memberName},`,
+    ``,
+    `${organizationName} a besoin de toi pour ${eventTitle}.`,
+    message ? `\n${message}\n` : ``,
+    `📅 ${eventDate}`,
+    eventLocation ? `📍 ${eventLocation}` : ``,
+    ``,
+    `Voir les missions : ${inviteUrl}`,
+  ].filter(Boolean).join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Bonjour ${escapeHtml(memberName)},</h2>
+    <p>${escapeHtml(organizationName)} a besoin de toi pour <strong>${escapeHtml(eventTitle)}</strong>.</p>
+    ${message ? `<p style="background:#f3f4f6;padding:12px;border-radius:8px">${escapeHtml(message)}</p>` : ""}
+    <p>📅 ${escapeHtml(eventDate)}${eventLocation ? `<br>📍 ${escapeHtml(eventLocation)}` : ""}</p>
+    <p style="margin-top:1.5em">${btn(inviteUrl, "Voir les missions et m'inscrire")}</p>
+    <p style="color:#888;font-size:0.85em;margin-top:2em">Si tu ne peux pas, ignore cet email.</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Rappels auto ─────────────────────────────────────────────────────────────
+
+type ReminderData = {
+  volunteerName: string
+  eventTitle: string
+  organizationName: string
+  shiftLabel: string
+  shiftRoleName: string
+  shiftDate: string
+  shiftStart: string
+  shiftEnd: string
+  shiftLocation: string | null
+  editToken: string
+  hoursUntil?: number
+}
+
+function renderReminderJ2(p: NotificationPayload): RenderedEmail {
+  const d = p.data as ReminderData
+  const editUrl = `${APP_URL}/my/${d.editToken}`
+  const subject = `J-2 — ${d.eventTitle}`
+
+  const text = [
+    `Bonjour ${d.volunteerName},`,
+    ``,
+    `Tu es inscrit·e pour ${d.eventTitle} dans 2 jours :`,
+    `📅 ${d.shiftDate}`,
+    `🕐 ${d.shiftStart} - ${d.shiftEnd}`,
+    d.shiftLocation ? `📍 ${d.shiftLocation}` : ``,
+    `Mission : ${d.shiftRoleName}`,
+    ``,
+    `Si tu ne peux plus venir, merci de nous prévenir : ${editUrl}`,
+  ].filter(Boolean).join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Plus que 2 jours !</h2>
+    <p>Bonjour ${escapeHtml(d.volunteerName)}, on se retrouve bientôt pour <strong>${escapeHtml(d.eventTitle)}</strong> :</p>
+    <ul style="padding-left:1.2em;line-height:1.8">
+      <li>📅 ${escapeHtml(d.shiftDate)}</li>
+      <li>🕐 ${escapeHtml(d.shiftStart)} – ${escapeHtml(d.shiftEnd)}</li>
+      ${d.shiftLocation ? `<li>📍 ${escapeHtml(d.shiftLocation)}</li>` : ""}
+      <li>Mission : <strong>${escapeHtml(d.shiftRoleName)}</strong></li>
+    </ul>
+    <p style="margin-top:1.5em">${btn(editUrl, "Annuler si je ne peux plus venir")}</p>
+    <p style="color:#888;font-size:0.85em">À très vite,<br>${escapeHtml(d.organizationName)}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+function renderReminderJ1(p: NotificationPayload): RenderedEmail {
+  const d = p.data as ReminderData
+  const editUrl = `${APP_URL}/my/${d.editToken}`
+  const subject = `Demain — ${d.eventTitle}`
+
+  const text = `Plus que 24h ! ${d.eventTitle} demain à ${d.shiftStart}${d.shiftLocation ? `, à ${d.shiftLocation}` : ""}.\nTu fais : ${d.shiftRoleName}\n\n${editUrl}`
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Plus que 24h !</h2>
+    <p><strong>${escapeHtml(d.eventTitle)}</strong> demain à ${escapeHtml(d.shiftStart)}${d.shiftLocation ? `, à ${escapeHtml(d.shiftLocation)}` : ""}.</p>
+    <p>Tu fais : <strong>${escapeHtml(d.shiftRoleName)}</strong></p>
+    <p style="margin-top:1.5em">${btn(editUrl, "Gérer mon inscription")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+function renderReminderDd(p: NotificationPayload): RenderedEmail {
+  const d = p.data as ReminderData
+  const editUrl = `${APP_URL}/my/${d.editToken}`
+  const subject = `C'est aujourd'hui — ${d.eventTitle}`
+  const hoursLabel = d.hoursUntil && d.hoursUntil > 0 ? `dans ${d.hoursUntil}h` : "très bientôt"
+
+  const text = `RDV ${hoursLabel} ! ${d.shiftLocation ?? ""} à ${d.shiftStart}\n\n${editUrl}`
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">RDV ${hoursLabel} !</h2>
+    ${d.shiftLocation ? `<p>📍 ${escapeHtml(d.shiftLocation)}</p>` : ""}
+    <p>🕐 ${escapeHtml(d.shiftStart)}</p>
+    <p>Mission : <strong>${escapeHtml(d.shiftRoleName)}</strong></p>
+    <p style="margin-top:1.5em">${btn(editUrl, "Voir mon inscription")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Rappel manuel J-7 ────────────────────────────────────────────────────────
+
+function renderManualReminder(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    volunteerName: string
+    organizationName: string
+    eventTitle: string
+    customMessage: string
+    shifts: { label: string; date: string; startTime: string; endTime: string; roleName: string }[]
+    editToken: string
+  }
+  const editUrl = `${APP_URL}/my/${d.editToken}`
+  const subject = `Rappel — ${d.eventTitle}`
+
+  const text = [
+    `Bonjour ${d.volunteerName},`,
+    ``,
+    d.customMessage,
+    ``,
+    `Vos créneaux pour ${d.eventTitle} :`,
+    ...d.shifts.map((s) => `  • ${s.date} · ${s.label} · ${s.startTime}–${s.endTime}`),
+    ``,
+    `Gérer vos inscriptions : ${editUrl}`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Bonjour ${escapeHtml(d.volunteerName)},</h2>
+    ${d.customMessage ? `<div style="background:#f3f4f6;padding:14px;border-radius:8px;white-space:pre-wrap">${escapeHtml(d.customMessage)}</div>` : ""}
+    <p style="margin-top:1.5em">Vos créneaux pour <strong>${escapeHtml(d.eventTitle)}</strong> :</p>
+    <ul style="padding-left:1.2em;line-height:1.8">
+      ${d.shifts.map((s) => `<li>${escapeHtml(s.date)} · <strong>${escapeHtml(s.label)}</strong> · ${escapeHtml(s.startTime)}–${escapeHtml(s.endTime)}</li>`).join("")}
+    </ul>
+    <p style="margin-top:1.5em">${btn(editUrl, "Gérer mes inscriptions")}</p>
+    <p style="color:#888;font-size:0.85em">${escapeHtml(d.organizationName)}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Notif modification d'un shift ────────────────────────────────────────────
+
+function renderShiftModified(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    volunteerName: string
+    eventTitle: string
+    shiftLabel: string
+    oldDate: string
+    newDate: string
+    oldStart: string
+    newStart: string
+    oldEnd: string
+    newEnd: string
+    editToken: string
+  }
+  const editUrl = `${APP_URL}/my/${d.editToken}`
+  const subject = `Changement d'horaire — ${d.eventTitle}`
+
+  const text = [
+    `Bonjour ${d.volunteerName},`,
+    ``,
+    `Le créneau "${d.shiftLabel}" pour ${d.eventTitle} a changé :`,
+    `Avant : ${d.oldDate} de ${d.oldStart} à ${d.oldEnd}`,
+    `Maintenant : ${d.newDate} de ${d.newStart} à ${d.newEnd}`,
+    ``,
+    `Si ces nouveaux horaires ne te conviennent pas : ${editUrl}`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Changement d'horaire</h2>
+    <p>Bonjour ${escapeHtml(d.volunteerName)}, le créneau <strong>${escapeHtml(d.shiftLabel)}</strong> pour <strong>${escapeHtml(d.eventTitle)}</strong> a été modifié :</p>
+    <p><span style="text-decoration:line-through;color:#999">${escapeHtml(d.oldDate)} · ${escapeHtml(d.oldStart)}–${escapeHtml(d.oldEnd)}</span></p>
+    <p style="font-weight:600">${escapeHtml(d.newDate)} · ${escapeHtml(d.newStart)}–${escapeHtml(d.newEnd)}</p>
+    <p style="margin-top:1.5em">${btn(editUrl, "Gérer mon inscription")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Notif annulation d'un shift ──────────────────────────────────────────────
+
+function renderShiftCancelled(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    volunteerName: string
+    eventTitle: string
+    eventSlug: string
+    shiftLabel: string
+    shiftDate: string
+  }
+  const eventUrl = `${APP_URL}/events/${d.eventSlug}`
+  const subject = `Créneau annulé — ${d.eventTitle}`
+
+  const text = [
+    `Bonjour ${d.volunteerName},`,
+    ``,
+    `Le créneau "${d.shiftLabel}" du ${d.shiftDate} a été annulé.`,
+    ``,
+    `Tu peux te réinscrire sur un autre créneau : ${eventUrl}`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Créneau annulé</h2>
+    <p>Bonjour ${escapeHtml(d.volunteerName)},</p>
+    <p>Le créneau <strong>${escapeHtml(d.shiftLabel)}</strong> du ${escapeHtml(d.shiftDate)} pour <strong>${escapeHtml(d.eventTitle)}</strong> a été annulé.</p>
+    <p style="margin-top:1.5em">${btn(eventUrl, "Voir les autres créneaux")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Inscription annulée (suite à #46 cancel public) ──────────────────────────
+
+function renderRegistrationCancelled(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    volunteerName: string
+    eventTitle: string
+    eventSlug: string
+    shiftLabel: string
+  }
+  const eventUrl = `${APP_URL}/events/${d.eventSlug}`
+  const subject = `Désinscription — ${d.eventTitle}`
+
+  const text = [
+    `Bonjour ${d.volunteerName},`,
+    ``,
+    `Ta désinscription du créneau "${d.shiftLabel}" pour ${d.eventTitle} est confirmée.`,
+    ``,
+    `Si tu changes d'avis : ${eventUrl}`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Désinscription confirmée</h2>
+    <p>Bonjour ${escapeHtml(d.volunteerName)},</p>
+    <p>Ta désinscription du créneau <strong>${escapeHtml(d.shiftLabel)}</strong> pour <strong>${escapeHtml(d.eventTitle)}</strong> est bien prise en compte.</p>
+    <p style="margin-top:1.5em">${btn(eventUrl, "Voir les créneaux disponibles")}</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Notif admin (interne) ────────────────────────────────────────────────────
+
+function renderAdminNotification(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    eventTitle: string
+    volunteerName: string
+    volunteerEmail: string
+    shifts: { label: string }[]
+  }
+  const subject = `Nouvelle inscription — ${d.eventTitle}`
+
+  const text = `${d.volunteerName} (${d.volunteerEmail}) vient de s'inscrire à ${d.eventTitle}.\nCréneaux : ${d.shifts.map((s) => s.label).join(", ")}`
+
+  const html = `
+    <p><strong>${escapeHtml(d.volunteerName)}</strong> (${escapeHtml(d.volunteerEmail)}) vient de s'inscrire à <strong>${escapeHtml(d.eventTitle)}</strong>.</p>
+    <p>Créneaux : ${d.shifts.map((s) => escapeHtml(s.label)).join(", ")}</p>
+  `
+
+  return { subject, html, text }
+}

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -51,6 +51,10 @@ export function render(payload: NotificationPayload): RenderedEmail {
       return renderRegistrationCancelled(payload)
     case "admin_notification":
       return renderAdminNotification(payload)
+    case "admin_invitation":
+      return renderAdminInvitation(payload)
+    case "password_reset":
+      return renderPasswordReset(payload)
   }
 }
 
@@ -376,6 +380,82 @@ function renderAdminNotification(p: NotificationPayload): RenderedEmail {
     <p><strong>${escapeHtml(d.volunteerName)}</strong> (${escapeHtml(d.volunteerEmail)}) vient de s'inscrire à <strong>${escapeHtml(d.eventTitle)}</strong>.</p>
     <p>Créneaux : ${d.shifts.map((s) => escapeHtml(s.label)).join(", ")}</p>
   `
+
+  return { subject, html, text }
+}
+
+// ── Invitation admin ─────────────────────────────────────────────────────────
+
+function renderAdminInvitation(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    organizationName: string
+    inviterName: string
+    token: string
+    expiresAt: Date | string
+  }
+  const inviteUrl = `${APP_URL}/invite/${d.token}`
+  const expiresFormatted = new Date(d.expiresAt).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  })
+  const subject = `Invitation administrateur — ${d.organizationName}`
+
+  const text = [
+    `Bonjour,`,
+    ``,
+    `${d.inviterName} t'invite à rejoindre l'administration de ${d.organizationName} sur Bénévoles.`,
+    ``,
+    `Pour créer ton compte et accepter l'invitation :`,
+    inviteUrl,
+    ``,
+    `Ce lien est valable jusqu'au ${expiresFormatted}.`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Invitation à rejoindre ${escapeHtml(d.organizationName)}</h2>
+    <p><strong>${escapeHtml(d.inviterName)}</strong> t'invite à devenir administrateur de <strong>${escapeHtml(d.organizationName)}</strong> sur Bénévoles.</p>
+    <p style="margin-top:1.5em">${btn(inviteUrl, "Créer mon compte et accepter")}</p>
+    <p style="color:#888;font-size:0.85em;margin-top:2em">Ce lien expire le ${escapeHtml(expiresFormatted)}. Si tu ne reconnais pas cette invitation, ignore cet email.</p>
+  `)
+
+  return { subject, html, text }
+}
+
+// ── Reset mot de passe ───────────────────────────────────────────────────────
+
+function renderPasswordReset(p: NotificationPayload): RenderedEmail {
+  const d = p.data as {
+    userName: string
+    token: string
+    expiresAt: Date | string
+  }
+  const resetUrl = `${APP_URL}/admin/reset-password/${d.token}`
+  const expiresFormatted = new Date(d.expiresAt).toLocaleString("fr-FR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  })
+  const subject = `Réinitialisation de ton mot de passe`
+
+  const text = [
+    `Bonjour ${d.userName},`,
+    ``,
+    `Une demande de réinitialisation de mot de passe a été faite pour ton compte.`,
+    `Si ce n'était pas toi, ignore simplement cet email.`,
+    ``,
+    `Pour choisir un nouveau mot de passe :`,
+    resetUrl,
+    ``,
+    `Ce lien est valable jusqu'au ${expiresFormatted}.`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Réinitialisation de ton mot de passe</h2>
+    <p>Bonjour ${escapeHtml(d.userName)},</p>
+    <p>Une demande de réinitialisation a été faite pour ton compte. Si ce n'était pas toi, ignore cet email.</p>
+    <p style="margin-top:1.5em">${btn(resetUrl, "Choisir un nouveau mot de passe")}</p>
+    <p style="color:#888;font-size:0.85em;margin-top:2em">Lien valable jusqu'au ${escapeHtml(expiresFormatted)}.</p>
+  `)
 
   return { subject, html, text }
 }

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Notifications layer.
+ *
+ * Goal: keep the rest of the app provider-agnostic. Code calls
+ * `sendNotification(payload)` and never imports nodemailer / resend
+ * / twilio directly. Adding a new channel (SMS, WhatsApp) becomes a
+ * matter of adding one file under `channels/` without touching callers.
+ */
+
+export type NotificationChannel = "email" | "sms" | "whatsapp"
+
+export type NotificationKind =
+  | "registration_confirmation"
+  | "member_invite"
+  | "reminder_j2"
+  | "reminder_j1"
+  | "reminder_dd"
+  | "manual_reminder"
+  | "shift_modified"
+  | "shift_cancelled"
+  | "registration_cancelled"
+  | "admin_notification"
+
+export type Recipient = {
+  email?: string | null
+  phone?: string | null
+  name?: string
+}
+
+/**
+ * Payload of any notification. `data` carries the kind-specific
+ * variables consumed by the template. The shape is loose on purpose:
+ * each template knows its own contract.
+ */
+export type NotificationPayload<K extends NotificationKind = NotificationKind> = {
+  kind: K
+  recipient: Recipient
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: Record<string, any>
+}
+
+export interface NotificationChannelImpl {
+  readonly name: NotificationChannel
+  send(payload: NotificationPayload): Promise<{ ok: true } | { ok: false; reason: string }>
+}

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -20,6 +20,8 @@ export type NotificationKind =
   | "shift_cancelled"
   | "registration_cancelled"
   | "admin_notification"
+  | "admin_invitation"
+  | "password_reset"
 
 export type Recipient = {
   email?: string | null

--- a/src/lib/prisma-org.ts
+++ b/src/lib/prisma-org.ts
@@ -113,6 +113,29 @@ export function getOrgClient(organizationId: string) {
           return query(args)
         },
       },
+      memberInvite: {
+        async findMany({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = (args.where ?? {}) as any
+          w.event = { ...(w.event ?? {}), organizationId }
+          args.where = w
+          return query(args)
+        },
+        async findFirst({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = (args.where ?? {}) as any
+          w.event = { ...(w.event ?? {}), organizationId }
+          args.where = w
+          return query(args)
+        },
+        async count({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = (args.where ?? {}) as any
+          w.event = { ...(w.event ?? {}), organizationId }
+          args.where = w
+          return query(args)
+        },
+      },
     },
   })
 }

--- a/src/lib/prisma-org.ts
+++ b/src/lib/prisma-org.ts
@@ -1,0 +1,120 @@
+import { prisma } from "./prisma"
+
+/**
+ * Returns a Prisma client extended so every read on a tenant-owned model
+ * is automatically constrained to the given organization.
+ *
+ * Reads (findMany, findFirst, count) are scoped automatically. Mutations
+ * (update, delete) on Shift and Registration must still be guarded by the
+ * route by first calling a scoped read (e.g. db.shift.findFirst) to verify
+ * ownership — Prisma's WhereUniqueInput does not let us inject relation
+ * filters on these operations.
+ *
+ * Type assertions are used inside the callbacks because Prisma's generic
+ * argument types don't model runtime injection cleanly: the where/data
+ * objects are valid at runtime even when the static types are stricter.
+ */
+export function getOrgClient(organizationId: string) {
+  return prisma.$extends({
+    name: "org-scoped",
+    query: {
+      event: {
+        async findMany({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(args.where as any) = { ...args.where, organizationId }
+          return query(args)
+        },
+        async findFirst({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(args.where as any) = { ...args.where, organizationId }
+          return query(args)
+        },
+        async findFirstOrThrow({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(args.where as any) = { ...args.where, organizationId }
+          return query(args)
+        },
+        async count({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(args.where as any) = { ...(args.where ?? {}), organizationId }
+          return query(args)
+        },
+        async create({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(args.data as any) = { ...args.data, organizationId }
+          return query(args)
+        },
+      },
+      member: {
+        async findMany({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(args.where as any) = { ...args.where, organizationId }
+          return query(args)
+        },
+        async findFirst({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(args.where as any) = { ...args.where, organizationId }
+          return query(args)
+        },
+        async count({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(args.where as any) = { ...(args.where ?? {}), organizationId }
+          return query(args)
+        },
+        async create({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(args.data as any) = { ...args.data, organizationId }
+          return query(args)
+        },
+      },
+      shift: {
+        async findMany({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = (args.where ?? {}) as any
+          w.event = { ...(w.event ?? {}), organizationId }
+          args.where = w
+          return query(args)
+        },
+        async findFirst({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = (args.where ?? {}) as any
+          w.event = { ...(w.event ?? {}), organizationId }
+          args.where = w
+          return query(args)
+        },
+        async count({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = (args.where ?? {}) as any
+          w.event = { ...(w.event ?? {}), organizationId }
+          args.where = w
+          return query(args)
+        },
+      },
+      registration: {
+        async findMany({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = (args.where ?? {}) as any
+          w.event = { ...(w.event ?? {}), organizationId }
+          args.where = w
+          return query(args)
+        },
+        async findFirst({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = (args.where ?? {}) as any
+          w.event = { ...(w.event ?? {}), organizationId }
+          args.where = w
+          return query(args)
+        },
+        async count({ args, query }) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = (args.where ?? {}) as any
+          w.event = { ...(w.event ?? {}), organizationId }
+          args.where = w
+          return query(args)
+        },
+      },
+    },
+  })
+}
+
+export type OrgScopedPrisma = ReturnType<typeof getOrgClient>

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,22 @@
+import type { DefaultSession } from "next-auth"
+
+declare module "next-auth" {
+  interface User {
+    role?: string
+    organizationId?: string | null
+  }
+
+  interface Session {
+    user: {
+      role?: string
+      organizationId?: string | null
+    } & DefaultSession["user"]
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    role?: string
+    organizationId?: string | null
+  }
+}


### PR DESCRIPTION
## Summary

Sprint 4 closes the operational friction points your pilots will encounter in the first week of use: creating orgs without SQL, inviting a second admin, handling a forgotten password.

## Changes

**Schema** (`prisma/migrations/20260430100000_admin_invitations`)
- `Organization.isActive` (soft-delete)
- `AdminInvitation`: org invitation tokens, 7-day TTL, unique on `(email, organizationId)`, revocable
- `PasswordResetToken`: 1h TTL, single-use

**Notifications layer**
- 2 new kinds: `admin_invitation`, `password_reset`
- HTML + text templates with escaping

**Super admin UI (#36, reopened)**
- `/super-admin/organizations`: list + active/inactive toggle + counters
- `/super-admin/organizations/new`: creation + optional invitation of first admin
- API: GET/POST/GET[id]/PATCH[id]/DELETE[id], guarded by `requireSuperAdmin`
- Distinct nav (violet theme) for super_admin

**Multi-admin invitations (#32 #33 #34)**
- `/admin/settings/members`: team table + pending invitations + invitation modal
- `POST /api/admin/invitations`: idempotent on `(email, org)`, refreshes token if not revoked
- `DELETE /api/admin/invitations/[id]`: revoke
- `DELETE /api/admin/team/[id]`: deactivate, refuses self + last admin
- `/invite/[token]`: public account creation page, error handling (expired / accepted / revoked / org deactivated)

**Password reset (#42)**
- `/admin/forgot-password`: anti-enumeration (always 200)
- `/admin/reset-password/[token]`: form + validation
- `POST /api/public/forgot-password`, `GET/POST /api/public/reset-password/[token]`

**Nav**
- AdminNav: "Team" tab + "⚙ Super admin" shortcut if role=super_admin
- "Forgot password?" on `/admin/login`

## Test plan

- [ ] `prisma migrate deploy` applies the new migration
- [ ] Login as super_admin → "⚙ Super admin" visible → /super-admin/organizations
- [ ] Create a new org with invite → email in Mailpit + `/invite/[token]` link
- [ ] Click the link → "Welcome!" form → create account → redirect to login
- [ ] Login with the new account → admin scoped to the new org
- [ ] "Team" tab → pending invitations visible + revocation
- [ ] Deactivate yourself → rejected (400)
- [ ] Deactivate the last active admin → rejected (400)
- [ ] Forgot password → email in Mailpit → reset → new password works
- [ ] Unknown email on forgot-password → always 200 (anti-enumeration)
- [ ] Tests: 91 pass, tsc + eslint clean

## Issues

Closes #32 #33 #34 #36 #42

---
_Generated by [Claude Code](https://claude.ai/code/session_017XAA7o12GpsXpUeyGNynZH)_