### PR TITLE
feat(auth): password reset + env cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,5 @@
 DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/benevoles?schema=public"
 
-ADMIN_EMAIL="admin@votre-domaine.com"
-ADMIN_PASSWORD="changer-ce-mot-de-passe"
-
 AUTH_SECRET="une-chaine-aleatoire-32-chars-minimum"
 
 # SMTP — exemples courants :
@@ -30,3 +27,6 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # NextAuth v5 derrière un reverse proxy (obligatoire en production)
 AUTH_URL="http://localhost:3000"
 AUTH_TRUST_HOST="false"
+
+# Secret partagé pour le endpoint cron /api/cron/reminders (recommandé en prod)
+CRON_SECRET=""

--- a/prisma/migrations/20260501000000_add_password_reset_token/migration.sql
+++ b/prisma/migrations/20260501000000_add_password_reset_token/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "AdminUser" ADD COLUMN "passwordResetExpiresAt" TIMESTAMP(3);
+ALTER TABLE "AdminUser" ADD COLUMN "passwordResetToken" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdminUser_passwordResetToken_key" ON "AdminUser"("passwordResetToken");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -150,10 +150,12 @@ model AdminUser {
   passwordHash        String
   role                String    @default("admin")
   isActive            Boolean   @default(true)
-  setupToken          String?   @unique
-  setupTokenExpiresAt DateTime?
-  createdAt           DateTime  @default(now())
-  updatedAt           DateTime  @updatedAt
+  setupToken              String?   @unique
+  setupTokenExpiresAt     DateTime?
+  passwordResetToken      String?   @unique
+  passwordResetExpiresAt  DateTime?
+  createdAt               DateTime  @default(now())
+  updatedAt               DateTime  @updatedAt
 
   organization Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
 

--- a/src/app/admin/forgot-password/page.tsx
+++ b/src/app/admin/forgot-password/page.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("")
+  const [submitted, setSubmitted] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    await fetch("/api/public/forgot-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    })
+    setLoading(false)
+    setSubmitted(true)
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">Mot de passe oublié</h1>
+          <p className="text-gray-500 text-sm mt-1">
+            Entrez votre email pour recevoir un lien de réinitialisation.
+          </p>
+        </div>
+
+        {submitted ? (
+          <div className="bg-white rounded-2xl border border-gray-200 p-6 text-center space-y-3">
+            <p className="text-2xl">📬</p>
+            <p className="font-semibold text-gray-900">Email envoyé</p>
+            <p className="text-sm text-gray-500">
+              Si cette adresse est associée à un compte, vous recevrez un lien valable 1 heure.
+            </p>
+            <Link href="/admin/login" className="block text-sm text-blue-600 hover:underline mt-2">
+              Retour à la connexion
+            </Link>
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="bg-white rounded-2xl border border-gray-200 p-6 space-y-4"
+          >
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+              <input
+                type="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full border border-gray-300 rounded-xl px-3 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                autoComplete="email"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-gray-900 text-white rounded-xl py-3 text-sm font-medium hover:bg-gray-800 transition-colors disabled:opacity-50"
+            >
+              {loading ? "Envoi…" : "Envoyer le lien"}
+            </button>
+            <div className="text-center">
+              <Link href="/admin/login" className="text-sm text-gray-500 hover:text-gray-700">
+                Retour à la connexion
+              </Link>
+            </div>
+          </form>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { signIn } from "next-auth/react"
 import { useRouter } from "next/navigation"
+import Link from "next/link"
 
 export default function LoginPage() {
   const router = useRouter()
@@ -77,6 +78,11 @@ export default function LoginPage() {
           >
             {loading ? "Connexion…" : "Se connecter"}
           </button>
+          <div className="text-center">
+            <Link href="/admin/forgot-password" className="text-xs text-gray-400 hover:text-gray-600">
+              Mot de passe oublié ?
+            </Link>
+          </div>
         </form>
       </div>
     </main>

--- a/src/app/admin/reset-password/page.tsx
+++ b/src/app/admin/reset-password/page.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { useState, Suspense } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import Link from "next/link"
+
+function ResetForm() {
+  const searchParams = useSearchParams()
+  const token = searchParams.get("token") ?? ""
+  const router = useRouter()
+
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [done, setDone] = useState(false)
+
+  if (!token) {
+    return (
+      <div className="text-center py-8 space-y-3">
+        <p className="text-gray-500">Lien invalide ou manquant.</p>
+        <Link href="/admin/forgot-password" className="text-sm text-blue-600 hover:underline">
+          Demander un nouveau lien
+        </Link>
+      </div>
+    )
+  }
+
+  if (done) {
+    return (
+      <div className="text-center space-y-4 py-8">
+        <p className="text-2xl">✅</p>
+        <p className="font-semibold text-gray-900">Mot de passe mis à jour</p>
+        <p className="text-sm text-gray-500">Vous pouvez maintenant vous connecter.</p>
+        <button
+          onClick={() => router.push("/admin/login")}
+          className="bg-blue-600 text-white px-4 py-2 rounded-xl text-sm font-medium hover:bg-blue-700"
+        >
+          Se connecter
+        </button>
+      </div>
+    )
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (password !== confirm) {
+      setError("Les mots de passe ne correspondent pas.")
+      return
+    }
+    setLoading(true)
+    setError(null)
+
+    const res = await fetch("/api/public/reset-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token, password }),
+    })
+
+    setLoading(false)
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setError(typeof data?.error === "string" ? data.error : "Une erreur est survenue.")
+      return
+    }
+
+    setDone(true)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Nouveau mot de passe
+        </label>
+        <input
+          type="password"
+          required
+          minLength={8}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="8 caractères minimum"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Confirmer le mot de passe
+        </label>
+        <input
+          type="password"
+          required
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          className="w-full border border-gray-300 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+      {error && (
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          {error}
+        </p>
+      )}
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full bg-gray-900 text-white rounded-xl py-3 text-sm font-medium hover:bg-gray-800 transition-colors disabled:opacity-50"
+      >
+        {loading ? "Enregistrement…" : "Mettre à jour le mot de passe"}
+      </button>
+    </form>
+  )
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">Nouveau mot de passe</h1>
+          <p className="text-gray-500 text-sm mt-1">Choisissez un mot de passe sécurisé.</p>
+        </div>
+        <div className="bg-white rounded-2xl border border-gray-200 p-6">
+          <Suspense fallback={<p className="text-sm text-gray-400 text-center">Chargement…</p>}>
+            <ResetForm />
+          </Suspense>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/api/public/forgot-password/route.ts
+++ b/src/app/api/public/forgot-password/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server"
+import { randomBytes } from "crypto"
+import { prisma } from "@/lib/prisma"
+import { sendNotification } from "@/lib/notifications"
+
+export async function POST(req: Request) {
+  const { email } = await req.json().catch(() => ({}))
+  if (typeof email !== "string" || !email.includes("@")) {
+    return NextResponse.json({ error: "Email invalide." }, { status: 400 })
+  }
+
+  const admin = await prisma.adminUser.findUnique({ where: { email: email.toLowerCase().trim() } })
+
+  // Always return 200 to avoid user enumeration
+  if (!admin || !admin.isActive) {
+    return NextResponse.json({ ok: true })
+  }
+
+  const token = randomBytes(32).toString("hex")
+  const expiresAt = new Date(Date.now() + 60 * 60 * 1000) // 1 hour
+
+  await prisma.adminUser.update({
+    where: { id: admin.id },
+    data: { passwordResetToken: token, passwordResetExpiresAt: expiresAt },
+  })
+
+  const APP_URL = (process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000").replace(/\/$/, "")
+  const resetUrl = `${APP_URL}/admin/reset-password?token=${token}`
+
+  await sendNotification({
+    kind: "password_reset",
+    recipient: { email: admin.email, name: admin.name },
+    data: { adminName: admin.name, resetUrl },
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/public/reset-password/route.ts
+++ b/src/app/api/public/reset-password/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server"
+import bcrypt from "bcryptjs"
+import { prisma } from "@/lib/prisma"
+
+export async function POST(req: Request) {
+  const { token, password } = await req.json().catch(() => ({}))
+
+  if (typeof token !== "string" || typeof password !== "string" || password.length < 8) {
+    return NextResponse.json({ error: "Données invalides." }, { status: 400 })
+  }
+
+  const admin = await prisma.adminUser.findUnique({ where: { passwordResetToken: token } })
+
+  if (!admin || !admin.passwordResetExpiresAt || admin.passwordResetExpiresAt < new Date()) {
+    return NextResponse.json({ error: "Lien invalide ou expiré." }, { status: 400 })
+  }
+
+  const passwordHash = await bcrypt.hash(password, 12)
+
+  await prisma.adminUser.update({
+    where: { id: admin.id },
+    data: {
+      passwordHash,
+      passwordResetToken: null,
+      passwordResetExpiresAt: null,
+    },
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/legal/layout.tsx
+++ b/src/app/legal/layout.tsx
@@ -1,0 +1,9 @@
+export default function LegalLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-3xl mx-auto px-4 py-12 prose prose-sm prose-gray">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/app/legal/privacy/page.tsx
+++ b/src/app/legal/privacy/page.tsx
@@ -1,0 +1,193 @@
+export const metadata = { title: "Politique de confidentialité — benevol.app" }
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <h1>Politique de confidentialité</h1>
+      <p className="text-gray-500 text-sm">Dernière mise à jour : 30 avril 2026</p>
+
+      <p>
+        La présente politique décrit comment <strong>benevol.app</strong>, éditée par{" "}
+        <strong>[À PRÉCISER — entité juridique]</strong> (« nous »), collecte, utilise et protège
+        les données personnelles dans le cadre de son Service de gestion de bénévoles.
+      </p>
+
+      <h2>1. Qui traite quoi ?</h2>
+      <p>benevol.app est à la fois responsable du traitement et sous-traitant, selon les données :</p>
+      <ul>
+        <li>
+          <strong>Données des administrateurs d&apos;Organisations</strong> (nom, e-mail, mot de
+          passe) : benevol.app est <strong>responsable du traitement</strong>.
+        </li>
+        <li>
+          <strong>Données des bénévoles</strong> (nom, e-mail, disponibilités, présences) :
+          l&apos;Organisation est <strong>responsable du traitement</strong> ; benevol.app est{" "}
+          <strong>sous-traitant</strong> agissant sur instruction de l&apos;Organisation.
+        </li>
+      </ul>
+
+      <h2>2. Données que nous traitons en qualité de responsable</h2>
+
+      <h3>2.1 Administrateurs</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Donnée</th>
+            <th>Finalité</th>
+            <th>Base légale</th>
+            <th>Durée</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Nom, adresse e-mail</td>
+            <td>Création et gestion du compte</td>
+            <td>Exécution du contrat</td>
+            <td>Durée du compte + 30 jours</td>
+          </tr>
+          <tr>
+            <td>Mot de passe (hashé bcrypt)</td>
+            <td>Authentification</td>
+            <td>Exécution du contrat</td>
+            <td>Durée du compte</td>
+          </tr>
+          <tr>
+            <td>Logs de connexion</td>
+            <td>Sécurité et débogage</td>
+            <td>Intérêt légitime</td>
+            <td>90 jours</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>2.2 Cookies et stockage local</h3>
+      <p>
+        Nous utilisons un cookie de session (NextAuth) strictement nécessaire à
+        l&apos;authentification. Aucun cookie de pistage, analytique ou publicitaire n&apos;est
+        déposé.
+      </p>
+      <p>
+        L&apos;interface publique (formulaires bénévoles) utilise le <code>localStorage</code> du
+        navigateur pour mémoriser temporairement une session locale (sans compte). Ces données
+        restent sur l&apos;appareil de l&apos;utilisateur et ne sont pas transmises à nos serveurs.
+      </p>
+
+      <h2>3. Données que nous traitons en qualité de sous-traitant</h2>
+      <p>
+        Les données que les Organisations collectent sur leurs bénévoles (nom, e-mail,
+        disponibilités, présences, notes éventuelles) sont traitées exclusivement pour le compte de
+        l&apos;Organisation concernée.
+      </p>
+      <p>
+        En tant que sous-traitant, nous nous engageons à :
+      </p>
+      <ul>
+        <li>ne traiter ces données que sur instruction documentée de l&apos;Organisation ;</li>
+        <li>ne pas les vendre, louer ou partager avec des tiers non autorisés ;</li>
+        <li>
+          assurer une séparation stricte des données entre Organisations (isolation
+          multi-locataire) ;
+        </li>
+        <li>
+          notifier l&apos;Organisation sans délai injustifié en cas de violation de données la
+          concernant ;
+        </li>
+        <li>
+          supprimer ou restituer les données sur demande de l&apos;Organisation à l&apos;issue du
+          contrat.
+        </li>
+      </ul>
+      <p>
+        <strong>Les Organisations restent seules responsables</strong> de l&apos;information des
+        bénévoles sur le traitement de leurs données, de la base légale applicable et du respect du
+        RGPD ou de toute réglementation nationale applicable.
+      </p>
+
+      <h2>4. Transferts et sous-traitants</h2>
+      <p>
+        Les données sont hébergées sur des serveurs situés en{" "}
+        <strong>[À PRÉCISER — ex. Union européenne / Suisse]</strong>. Nous faisons appel aux
+        sous-traitants techniques suivants :
+      </p>
+      <ul>
+        <li>
+          <strong>Hébergeur</strong> : [À PRÉCISER — ex. Vercel / Hetzner / OVH] — hébergement de
+          l&apos;application
+        </li>
+        <li>
+          <strong>Base de données</strong> : [À PRÉCISER — ex. Supabase / Neon] — stockage des
+          données
+        </li>
+        <li>
+          <strong>Service e-mail transactionnel</strong> : [À PRÉCISER — ex. Resend / Sendgrid] —
+          envoi des notifications
+        </li>
+      </ul>
+      <p>
+        Chaque sous-traitant est lié par un accord de traitement de données conforme aux exigences
+        du RGPD.
+      </p>
+
+      <h2>5. Sécurité</h2>
+      <p>Nous mettons en œuvre les mesures techniques et organisationnelles suivantes :</p>
+      <ul>
+        <li>Chiffrement des communications (HTTPS/TLS) ;</li>
+        <li>Mots de passe hashés (bcrypt, facteur de coût 12) ;</li>
+        <li>Isolation des données entre Organisations (multi-tenancy strict) ;</li>
+        <li>Tokens de réinitialisation de mot de passe à usage unique, expirés après 1 heure ;</li>
+        <li>Accès à la base de données restreint aux composants applicatifs ;</li>
+        <li>Sauvegardes régulières chiffrées.</li>
+      </ul>
+      <p>
+        Le Service est fourni gratuitement et en l&apos;état. Malgré nos efforts, aucune mesure de
+        sécurité n&apos;est infaillible.
+      </p>
+
+      <h2>6. Droits des personnes concernées</h2>
+      <p>
+        Conformément au RGPD (ou à la loi fédérale suisse sur la protection des données, selon la
+        juridiction applicable), vous disposez des droits suivants :
+      </p>
+      <ul>
+        <li>Droit d&apos;accès, de rectification et d&apos;effacement de vos données ;</li>
+        <li>Droit à la portabilité ;</li>
+        <li>Droit d&apos;opposition et de limitation du traitement ;</li>
+        <li>Droit d&apos;introduire une réclamation auprès de l&apos;autorité de contrôle compétente.</li>
+      </ul>
+      <p>
+        <strong>Pour les administrateurs</strong> : exercez vos droits à{" "}
+        <a href="mailto:contact@benevol.app">contact@benevol.app</a>.
+      </p>
+      <p>
+        <strong>Pour les bénévoles</strong> : vos données étant contrôlées par l&apos;Organisation
+        qui vous a invité(e), adressez votre demande directement à cette Organisation. Nous
+        transmettrons toute demande reçue par erreur à l&apos;Organisation concernée dans un délai
+        de 72 heures.
+      </p>
+
+      <h2>7. Conservation des données</h2>
+      <p>
+        Les données des bénévoles sont conservées tant que l&apos;Organisation maintient son compte
+        sur la plateforme. Elles sont supprimées dans un délai de 30 jours suivant la clôture du
+        compte de l&apos;Organisation.
+      </p>
+      <p>
+        Les données des administrateurs sont supprimées dans un délai de 30 jours suivant la
+        désactivation ou la suppression du compte.
+      </p>
+
+      <h2>8. Modifications</h2>
+      <p>
+        Nous pouvons mettre à jour cette politique à tout moment. La date de dernière mise à jour
+        est indiquée en haut du document. Pour les modifications substantielles, nous notifierons
+        les administrateurs par e-mail.
+      </p>
+
+      <h2>9. Contact</h2>
+      <p>
+        Pour toute question relative à cette politique ou à l&apos;exercice de vos droits :{" "}
+        <a href="mailto:contact@benevol.app">contact@benevol.app</a>
+      </p>
+    </>
+  )
+}

--- a/src/app/legal/terms/page.tsx
+++ b/src/app/legal/terms/page.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link"
+
+export const metadata = { title: "Conditions générales d'utilisation — benevol.app" }
+
+export default function TermsPage() {
+  return (
+    <>
+      <h1>Conditions générales d&apos;utilisation</h1>
+      <p className="text-gray-500 text-sm">Dernière mise à jour : 30 avril 2026</p>
+
+      <h2>1. Objet</h2>
+      <p>
+        Les présentes conditions générales d&apos;utilisation (« CGU ») régissent l&apos;accès et
+        l&apos;utilisation de la plateforme <strong>benevol.app</strong> (le « Service »), éditée
+        par <strong>[À PRÉCISER — entité juridique]</strong> (« nous »).
+      </p>
+      <p>
+        En accédant au Service, l&apos;utilisateur accepte les présentes CGU sans réserve.
+      </p>
+
+      <h2>2. Description du Service</h2>
+      <p>
+        benevol.app est une plateforme de gestion des bénévoles destinée aux associations et
+        organisateurs d&apos;événements (les « Organisations »). Elle permet de créer des
+        formulaires d&apos;inscription pour bénévoles, de gérer les présences et d&apos;envoyer
+        des communications automatisées.
+      </p>
+      <p>
+        Le Service est fourni <strong>gratuitement</strong> et sans garantie, dans l&apos;état où
+        il se trouve (« as is »). Nous faisons de notre mieux pour assurer la disponibilité et la
+        fiabilité du Service, mais nous n&apos;offrons aucune garantie de continuité, d&apos;absence
+        d&apos;erreur ou d&apos;adéquation à un usage particulier.
+      </p>
+
+      <h2>3. Accès et comptes</h2>
+      <p>
+        L&apos;accès à l&apos;interface d&apos;administration est réservé aux personnes invitées
+        par un administrateur d&apos;Organisation. Tout compte est nominatif et non cessible.
+      </p>
+      <p>
+        L&apos;utilisateur est responsable de la confidentialité de ses identifiants et de toute
+        activité effectuée depuis son compte.
+      </p>
+      <p>
+        Les bénévoles n&apos;ont pas de compte sur la plateforme : leur participation est
+        enregistrée via un formulaire public et ils ne se connectent pas au Service.
+      </p>
+
+      <h2>4. Utilisation acceptable</h2>
+      <p>
+        L&apos;utilisateur s&apos;engage à utiliser le Service conformément à la loi et aux
+        présentes CGU. Sont notamment interdits :
+      </p>
+      <ul>
+        <li>
+          tout usage à des fins illégales, frauduleuses ou portant atteinte aux droits de tiers ;
+        </li>
+        <li>la collecte de données personnelles à des fins non liées à la gestion de bénévoles ;</li>
+        <li>toute tentative de contournement des mesures de sécurité du Service ;</li>
+        <li>
+          l&apos;envoi de communications non sollicitées (spam) via les outils de messagerie du
+          Service.
+        </li>
+      </ul>
+
+      <h2>5. Données personnelles</h2>
+      <p>
+        Dans le cadre du Service, deux types de traitement coexistent :
+      </p>
+      <ul>
+        <li>
+          <strong>Données des administrateurs</strong> (nom, adresse e-mail, mot de passe hashé) :
+          traitées par benevol.app en qualité de responsable du traitement, conformément à notre{" "}
+          <Link href="/legal/privacy">Politique de confidentialité</Link>.
+        </li>
+        <li>
+          <strong>Données des bénévoles</strong> (nom, e-mail, disponibilités, etc.) : collectées
+          par l&apos;Organisation via le Service. L&apos;Organisation agit en qualité de responsable
+          du traitement ; benevol.app agit en qualité de sous-traitant. L&apos;Organisation est
+          seule responsable de la base légale du traitement, de l&apos;information des bénévoles et
+          du respect du RGPD ou de la législation applicable.
+        </li>
+      </ul>
+      <p>
+        benevol.app s&apos;engage à traiter les données des bénévoles exclusivement pour les
+        besoins du Service, à ne pas les vendre ni les communiquer à des tiers non autorisés, et à
+        les supprimer sur demande de l&apos;Organisation.
+      </p>
+
+      <h2>6. Responsabilité et limitation de garantie</h2>
+      <p>
+        Le Service est fourni gratuitement et <strong>en l&apos;état, sans garantie d&apos;aucune
+        sorte</strong>, expresse ou implicite. Dans toute la mesure permise par la loi applicable,
+        nous déclinons toute responsabilité pour :
+      </p>
+      <ul>
+        <li>
+          toute interruption, erreur, perte de données ou indisponibilité du Service ;
+        </li>
+        <li>
+          tout dommage direct ou indirect résultant de l&apos;utilisation ou de l&apos;impossibilité
+          d&apos;utiliser le Service ;
+        </li>
+        <li>
+          tout contenu, données ou communication transmis via le Service par les Organisations ou
+          les bénévoles.
+        </li>
+      </ul>
+
+      <h2>7. Suspension et résiliation</h2>
+      <p>
+        Nous nous réservons le droit de suspendre ou supprimer l&apos;accès au Service, à tout
+        moment et sans préavis, en cas de violation des présentes CGU, d&apos;utilisation abusive
+        ou pour toute autre raison légitime.
+      </p>
+      <p>
+        Une Organisation peut demander la suppression de son compte et de l&apos;ensemble de ses
+        données en nous contactant à <a href="mailto:contact@benevol.app">contact@benevol.app</a>.
+      </p>
+
+      <h2>8. Modifications</h2>
+      <p>
+        Nous pouvons modifier les présentes CGU à tout moment. Les modifications entrent en vigueur
+        dès leur publication. L&apos;utilisation continue du Service après publication vaut
+        acceptation des nouvelles conditions.
+      </p>
+
+      <h2>9. Droit applicable et juridiction</h2>
+      <p>
+        Les présentes CGU sont régies par le droit [suisse / français — À PRÉCISER]. Tout litige
+        sera soumis à la juridiction exclusive des tribunaux de [ville — À PRÉCISER].
+      </p>
+
+      <h2>10. Contact</h2>
+      <p>
+        Pour toute question relative aux présentes CGU :{" "}
+        <a href="mailto:contact@benevol.app">contact@benevol.app</a>
+      </p>
+    </>
+  )
+}

--- a/src/lib/notifications/templates.ts
+++ b/src/lib/notifications/templates.ts
@@ -53,6 +53,8 @@ export function render(payload: NotificationPayload): RenderedEmail {
       return renderAdminNotification(payload)
     case "admin_invite":
       return renderAdminInvite(payload)
+    case "password_reset":
+      return renderPasswordReset(payload)
   }
 }
 
@@ -411,6 +413,32 @@ function renderAdminNotification(p: NotificationPayload): RenderedEmail {
     <p><strong>${escapeHtml(d.volunteerName)}</strong> (${escapeHtml(d.volunteerEmail)}) vient de s'inscrire à <strong>${escapeHtml(d.eventTitle)}</strong>.</p>
     <p>Créneaux : ${d.shifts.map((s) => escapeHtml(s.label)).join(", ")}</p>
   `
+
+  return { subject, html, text }
+}
+
+// ── Réinitialisation mot de passe ────────────────────────────────────────────
+
+function renderPasswordReset(p: NotificationPayload): RenderedEmail {
+  const d = p.data as { adminName: string; resetUrl: string }
+  const subject = `Réinitialisation de votre mot de passe`
+
+  const text = [
+    `Bonjour ${d.adminName},`,
+    ``,
+    `Vous avez demandé à réinitialiser votre mot de passe. Cliquez sur le lien ci-dessous (valable 1 heure) :`,
+    d.resetUrl,
+    ``,
+    `Si vous n'avez pas fait cette demande, ignorez cet email — votre mot de passe reste inchangé.`,
+  ].join("\n")
+
+  const html = wrap(`
+    <h2 style="margin:0 0 0.5em">Réinitialisation de mot de passe</h2>
+    <p>Bonjour ${escapeHtml(d.adminName)},</p>
+    <p>Vous avez demandé à réinitialiser votre mot de passe.</p>
+    <p style="margin-top:1.5em">${btn(d.resetUrl, "Réinitialiser mon mot de passe")}</p>
+    <p style="color:#888;font-size:0.85em;margin-top:2em">Ce lien est valable 1 heure. Si vous n'avez pas fait cette demande, ignorez cet email.</p>
+  `)
 
   return { subject, html, text }
 }

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -21,6 +21,7 @@ export type NotificationKind =
   | "registration_cancelled"
   | "admin_notification"
   | "admin_invite"
+  | "password_reset"
 
 export type Recipient = {
   email?: string | null


### PR DESCRIPTION
Closes #39, #42

## Summary
- Password reset flow: `/admin/forgot-password` → email with token → `/admin/reset-password?token=…` → new password
- Token stored in DB, expires in 1 hour, cleared after use — no user enumeration (always 200 on forgot-password)
- New `password_reset` notification kind with email template
- "Mot de passe oublié ?" link added to login page
- `.env.example`: removed stale `ADMIN_EMAIL`/`ADMIN_PASSWORD`, added `CRON_SECRET`
- Prisma migration: `passwordResetToken` + `passwordResetExpiresAt` on `AdminUser`

## Test plan
- [ ] Request reset for an existing admin → email arrives in Mailpit with valid link
- [ ] Click link → reset page → set new password → redirected to login → can sign in
- [ ] Expired token (> 1h) → error message
- [ ] Unknown email → no email sent, UI still shows success (no enumeration)
- [ ] Token consumed after first use → second use returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)