### PR TITLE
fix(docker): bump Go builder to 1.23 to match go.mod

### DIFF
--- a/gandi-webhook/Dockerfile
+++ b/gandi-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.23-alpine AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Summary

- The security dep bump in #79 caused `go mod tidy` to upgrade `go 1.20 → 1.23.0` in `gandi-webhook/go.mod`
- Dockerfile still used `golang:1.21-alpine`, causing Docker build failure in CI
- Bumps builder image to `golang:1.23-alpine`

## Test plan

- [ ] CI Docker build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)